### PR TITLE
fix tslint error about double quotes

### DIFF
--- a/src/JSONSchema.ts
+++ b/src/JSONSchema.ts
@@ -1,6 +1,6 @@
 export namespace JSONSchema {
 
-  export type SimpleTypes = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+  export type SimpleTypes = 'array' | 'boolean' | 'integer' | 'null' | 'number' | 'object' | 'string';
   /** Core schema meta-schema */
   export type HttpJsonSchemaOrgDraft04Schema = {
     id?: string;


### PR DESCRIPTION
See https://github.com/darcyparker/json-schema-to-typescript/blob/tslintDoubleQuoteError/tslint.json#L29

I was getting an error about the quotes in this file. I changed them to single quote.