### PR TITLE
Use single quote literals in output for tslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run build-sources && npm test && npm run lint",
     "build-sources": "tsc -p ./tsconfig.json",
-    "build-tests": "tsc -p ./tsconfig.test.json",
+    "build-tests": "rm -rf ./dist_tests && tsc -p ./tsconfig.test.json",
     "watch": "tsc -p ./tsconfig.json --watch && tsc -p ./tsconfig.test.json --watch",
     "lint": "tslint -c tslint.json src/*.ts",
     "test": "npm run build-tests && ava",

--- a/src/TsTypes.ts
+++ b/src/TsTypes.ts
@@ -103,7 +103,13 @@ export namespace TsType {
   export class Literal extends TsTypeBase {
     constructor(private value: any) { super() }
     _type() {
-      return JSON.stringify(this.value)
+      // if Literal is a string, format result with single quoted string literals
+      var stringValue = JSON.stringify(this.value)
+      const lastPos = stringValue.length - 1
+      if (stringValue.charAt(0) === '"' && stringValue.charAt(lastPos) === '"') {
+        stringValue = `'${stringValue.substring(1, lastPos).replace(/'/g,'\\\'')}'`
+      }
+      return stringValue
     }
   }
 

--- a/test/cases/additionalProperties.ts
+++ b/test/cases/additionalProperties.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "AdditionalProperties",
   "type": "object",
@@ -10,6 +11,7 @@ export var schema = {
     "type": "number"
   }
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var types = `export interface AdditionalProperties {
   foo?: string;

--- a/test/cases/allOf.ts
+++ b/test/cases/allOf.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "AllOf",
   "type": "object",
@@ -30,6 +31,7 @@ export var schema = {
   "required": ["foo", "bar"],
   "additionalProperties": false
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var types = `export interface Foo {
   a: string;

--- a/test/cases/anyOf.ts
+++ b/test/cases/anyOf.ts
@@ -37,7 +37,6 @@ export var schema = {
 }
 /* tslint:enable:quotemark object-literal-key-quotes */
 
-
 export var types = `export interface Foo {
   a: string;
   b?: number;

--- a/test/cases/anyOf.ts
+++ b/test/cases/anyOf.ts
@@ -41,7 +41,7 @@ export var types = `export interface Foo {
   b?: number;
 }
 export interface Bar {
-  a?: "a" | "b" | "c";
+  a?: 'a' | 'b' | 'c';
   [k: string]: any;
 }
 export interface Baz {

--- a/test/cases/anyOf.ts
+++ b/test/cases/anyOf.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "AnyOf",
   "type": "object",
@@ -34,6 +35,7 @@ export var schema = {
   "required": ["foo"],
   "additionalProperties": false
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 
 export var types = `export interface Foo {

--- a/test/cases/array-of-type.ts
+++ b/test/cases/array-of-type.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "Array of type",
   "type": "object",
@@ -22,6 +23,7 @@ export var schema = {
     }
   }
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var types =  `export interface ArrayOfType {
   foo?: string[];

--- a/test/cases/basics.ts
+++ b/test/cases/basics.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "Example Schema",
   "type": "object",
@@ -25,6 +26,7 @@ export var schema = {
   },
   "required": ["firstName", "lastName"]
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var configurations = [
   {

--- a/test/cases/disjoint-type.ts
+++ b/test/cases/disjoint-type.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "Example Schema",
   "description": "My cool schema",
@@ -12,6 +13,7 @@ export var schema = {
   },
   "required": ["value"]
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var types = `/**
  * My cool schema

--- a/test/cases/enum.ts
+++ b/test/cases/enum.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "Enum",
   "type": "object",
@@ -47,6 +48,7 @@ export var schema = {
   "required": ["stringEnum", "impliedStringEnum", "literalWithSingleQuote", "booleanEnum", "impliedBooleanEnum", "integerEnum", "impliedIntegerEnum", "impliedNamedIntegerEnum"],
   "additionalProperties": false
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var configurations = [false, true].map(useConstEnums => {
   return {

--- a/test/cases/enum.ts
+++ b/test/cases/enum.ts
@@ -9,6 +9,10 @@ export var schema = {
     "impliedStringEnum": {
       "enum": ["a", "b", "c"]
     },
+    "literalWithSingleQuote": {
+      "type": "string",
+      "enum": ["Some 'string' with inner single quote", "b", "c"]
+    },
     "booleanEnum": {
       "type" : "boolean",
       "enum": [ true ]
@@ -40,7 +44,7 @@ export var schema = {
       "enum": [-20.1, null, "foo", false]
     }
   },
-  "required": ["stringEnum", "impliedStringEnum", "booleanEnum", "impliedBooleanEnum", "integerEnum", "impliedIntegerEnum", "impliedNamedIntegerEnum"],
+  "required": ["stringEnum", "impliedStringEnum", "literalWithSingleQuote", "booleanEnum", "impliedBooleanEnum", "integerEnum", "impliedIntegerEnum", "impliedNamedIntegerEnum"],
   "additionalProperties": false
 }
 
@@ -61,8 +65,9 @@ export${useConstEnums ? ' const ' : ' '}enum ImpliedNamedIntegerEnum {
   Six = 6
 }
 export interface Enum {
-  stringEnum: "a" | "b" | "c";
-  impliedStringEnum: "a" | "b" | "c";
+  stringEnum: 'a' | 'b' | 'c';
+  impliedStringEnum: 'a' | 'b' | 'c';
+  literalWithSingleQuote: 'Some \\\'string\\\' with inner single quote' | 'b' | 'c';
   booleanEnum: true;
   impliedBooleanEnum: true;
   integerEnum: -1 | 0 | 1;
@@ -70,7 +75,7 @@ export interface Enum {
   numberEnum?: -1.1 | 0 | 1.2;
   namedIntegerEnum?: NamedIntegerEnum;
   impliedNamedIntegerEnum: ImpliedNamedIntegerEnum;
-  impliedHeterogeneousEnum?: -20.1 | null | "foo" | false;
+  impliedHeterogeneousEnum?: -20.1 | null | 'foo' | false;
 }`
   }
 })

--- a/test/cases/enum.ts
+++ b/test/cases/enum.ts
@@ -35,11 +35,11 @@ export var schema = {
     "namedIntegerEnum": {
       "type": "integer",
       "enum": [1, 2, 3],
-      "tsEnumNames": ["One","Two","Three"]
+      "tsEnumNames": ["One", "Two", "Three"]
     },
     "impliedNamedIntegerEnum": {
       "enum": [4, 5, 6],
-      "tsEnumNames": ["Four","Five","Six"]
+      "tsEnumNames": ["Four", "Five", "Six"]
     },
     "impliedHeterogeneousEnum": {
       "enum": [-20.1, null, "foo", false]

--- a/test/cases/enumValidation.5.ts
+++ b/test/cases/enumValidation.5.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "Enum",
   "type": "object",
@@ -11,6 +12,7 @@ export var schema = {
   "required": ["bar"],
   "additionalProperties": false
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var settings = {
   useTypescriptEnums: true

--- a/test/cases/enumValidation.6.ts
+++ b/test/cases/enumValidation.6.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "Enum",
   "type": "object",
@@ -11,6 +12,7 @@ export var schema = {
   "required": ["bar"],
   "additionalProperties": false
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var settings = {
   useTypescriptEnums: true

--- a/test/cases/json-schema.ts
+++ b/test/cases/json-schema.ts
@@ -158,7 +158,7 @@ export var configurations = [
 export type PositiveIntegerDefault0 = PositiveInteger;
 export type SchemaArray = HttpJsonSchemaOrgDraft04Schema[];
 export type StringArray = string[];
-export type SimpleTypes = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+export type SimpleTypes = 'array' | 'boolean' | 'integer' | 'null' | 'number' | 'object' | 'string';
 /**
  * Core schema meta-schema
  */
@@ -210,7 +210,7 @@ export interface HttpJsonSchemaOrgDraft04Schema {
     settings: {
         declareSimpleType: false
     },
-    types:`export type SimpleTypes = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string";
+    types:`export type SimpleTypes = 'array' | 'boolean' | 'integer' | 'null' | 'number' | 'object' | 'string';
 /**
  * Core schema meta-schema
  */

--- a/test/cases/json-schema.ts
+++ b/test/cases/json-schema.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
     "id": "http://json-schema.org/draft-04/schema#",
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -148,6 +149,7 @@ export var schema = {
     },
     "default": {}
 };
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var configurations = [
 {

--- a/test/cases/json-schema.ts
+++ b/test/cases/json-schema.ts
@@ -148,7 +148,7 @@ export var schema = {
         "exclusiveMinimum": [ "minimum" ]
     },
     "default": {}
-};
+}
 /* tslint:enable:quotemark object-literal-key-quotes */
 
 export var configurations = [

--- a/test/cases/named-property.ts
+++ b/test/cases/named-property.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "Example Schema",
   "description": "My cool schema",
@@ -13,6 +14,7 @@ export var schema = {
     }
   }
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 // TODO: 2nd block comment should annotate UserIdArray, not users
 export var types = `export type UserIdArray = string[];

--- a/test/cases/not-extendable.ts
+++ b/test/cases/not-extendable.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "Example Schema",
   "type": "object",
@@ -17,6 +18,7 @@ export var schema = {
   "required": ["firstName", "lastName"],
   "additionalProperties": false
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var types = `export interface ExampleSchema {
   firstName: string;

--- a/test/cases/ref.ts
+++ b/test/cases/ref.ts
@@ -1,5 +1,5 @@
-export var schema =
-{
+/* tslint:disable:quotemark object-literal-key-quotes */
+export var schema = {
   "title": "Referencing",
   "type": "object",
   "properties": {
@@ -10,6 +10,7 @@ export var schema =
   "required": ["foo"],
   "additionalProperties": false
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var configurations = [
   {

--- a/test/cases/root-anyOf.ts
+++ b/test/cases/root-anyOf.ts
@@ -32,7 +32,7 @@ export var types = `export interface Foo {
   b?: number;
 }
 export interface Bar {
-  a?: "a" | "b" | "c";
+  a?: 'a' | 'b' | 'c';
   [k: string]: any;
 }
 export interface Baz {

--- a/test/cases/root-anyOf.ts
+++ b/test/cases/root-anyOf.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "RootAnyOf",
   "anyOf": [
@@ -26,6 +27,7 @@ export var schema = {
     }
   }
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var types = `export interface Foo {
   a: string;

--- a/test/cases/unnamedSchema.ts
+++ b/test/cases/unnamedSchema.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "type": "object",
   "properties": {
@@ -8,6 +9,7 @@ export var schema = {
   "required": ["foo"],
   "additionalProperties": false
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var types = `export interface UnnamedSchema {
   foo: string;

--- a/test/cases/with-description-newlines.ts
+++ b/test/cases/with-description-newlines.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "Example Schema",
   "description": "My cool schema",
@@ -18,6 +19,7 @@ export var schema = {
   },
   "required": ["firstName", "lastName"]
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var types = `/**
  * My cool schema

--- a/test/cases/with-description.ts
+++ b/test/cases/with-description.ts
@@ -1,3 +1,4 @@
+/* tslint:disable:quotemark object-literal-key-quotes */
 export var schema = {
   "title": "Example Schema",
   "description": "My cool schema",
@@ -17,6 +18,7 @@ export var schema = {
   },
   "required": ["firstName", "lastName"]
 }
+/* tslint:enable:quotemark object-literal-key-quotes */
 
 export var types = `/**
  * My cool schema


### PR DESCRIPTION
@bcherny - I revised this pull request based on last week's feedback to add tests. It is also rebased on top of the latest master.

I am not sure if the tests are where you'd like them.  Some of the existing cases already test the single quotes. But I put some explicit ones here: https://github.com/bcherny/json-schema-to-typescript/pull/42/commits/8181b0c35e7d31799e6db6836f4b45e440aa7c2b#diff-632988bf801a8c538f18e7c4e222d9caR7