### PR TITLE
Add CLI utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .DS_Store
 npm-debug.log
 node_modules
-*.js
+./*.js
 *.map
 dist/
 dist_tests/

--- a/README.md
+++ b/README.md
@@ -53,12 +53,25 @@ export interface ExampleSchema {
 
 `npm install json-schema-to-typescript`
 
+or, to install the `json-schema-to-typescript` CLI utility:
+
+`npm install -g json-schema-to-typescript`
+
 ## Usage
+### API
 
 ```js
 import {compileFromFile} from 'json-schema-to-typescript'
 
 fs.writeFileSync('dist/foo.d.ts', await compileFromFile('src/foo.json'))
+```
+
+### CLI
+```
+$ json-schema-to-typescript src/foo.json
+... snipped output here, on stdout ...
+$ json-schema-to-typescript src/foo.json dist/foo.d.ts
+$
 ```
 
 See [/example](example) for a fully working demo.

--- a/bin/json-schema-to-typescript.js
+++ b/bin/json-schema-to-typescript.js
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+var fs = require('fs');
+var program = require('commander');
+
+var pkg = require('../package.json');
+
+var lib = require('../dist/index.js');
+var compileFromFile = lib.compileFromFile;
+
+program
+  .version(pkg.version)
+  .command('json-schema-to-typescript <in> [out]', 'convert a JSON-schema <in> file and output a TypeScript [out] file, or stdout if [out] file is not specified')
+  .action(function (inFile, outFile) {
+    outFile = (typeof outFile === 'string' ? outFile : null);
+
+    return compileFromFile(inFile).then(function (output) {
+      if (!outFile) {
+        console.log(output);
+        process.exit(0);
+      }
+
+      return fs.writeFileSync(outFile, output);
+    }, function () {
+      console.error('Could not compile from JSON-schema file', inFile);
+      process.exit(-1);
+    });
+  })
+  .parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "tdd": "npm run watch & ava --watch",
     "prepublish": "npm run build"
   },
+  "bin": {
+    "json-schema-to-typescript": "./bin/json-schema-to-typescript.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bcherny/json-schema-to-typescript.git"
@@ -36,6 +39,7 @@
   },
   "homepage": "https://github.com/bcherny/json-schema-to-typescript#readme",
   "dependencies": {
+    "commander": "^2.9.0",
     "lodash": "^4.6.1"
   },
   "devDependencies": {


### PR DESCRIPTION
...so that `json-schema-to-typescript` can be used as part of build processes easily, or just tested without having to write any javascript bindings.

This is the first thing I looked for while evaluating the tool. Super cool work! 