### PR TITLE
Basic support for patternProperties

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -252,11 +252,22 @@ function parseSchema(
   processed: Processed
 ): TInterfaceParam[] {
 
-  const asts = map(schema.properties, (value, key: string) => ({
+  let asts = map(schema.properties, (value, key: string) => ({
     ast: parse(value, rootSchema, key, true, processed),
     isRequired: includes(schema.required || [], key),
     keyName: key
   }))
+
+  // Very basic support for patternProperties.
+  if (schema.patternProperties) {
+    const patternProps = map(schema.patternProperties, (value, key: string) => ({
+      ast: parse(value, rootSchema, key, true, processed),
+      isRequired: includes(schema.required || [], key),
+      keyName: '[k: string]'
+    }))
+
+    asts = asts.concat(patternProps)
+  }
 
   // handle additionalProperties
   switch (schema.additionalProperties) {


### PR DESCRIPTION
## Overview

This is a quick fork I put together to add basic for `patternProperties` by adding `[k: string]` as the key. While this doesn't do any of the magic `patternProperties` should do, it at least gives typing support for an example such as this instead of interfaces not being filled at all:

```json
{
  "id": "example.json",
  "type": "object",
  "additionalProperties": false,
  "patternProperties": {
    ".+": {
      "additionalProperties": false,
      "properties": {
        "reference": {
          "type": "string"
        },
      },
      "required": [
        "reference"
      ]
    }
  }
}
```

```typescript
export interface Example {
  [k: string]?: {
    reference: string;
  };
}
```

I'm assuming people who are moving over to using Typescript interfaces are likely still using JSONSchema somewhere else in the stack (such as tests) so patternProperties is still used correctly that way. Possibly having a section called something like `minimum support` in the README could be useful. If something like this doesn't fit the path of the project however, feel free to close! Just wanted to share incase it could be of use.