### PR TITLE
Prevent logging from clashing with `debug` module.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 ## Tips
 
 - Use `npm run tdd` to compile and re-run tests when a file is modified
-- Use `DEBUG=true npm run tdd` to add logging output to the above command
+- Use `VERBOSE=true npm run tdd` to add logging output to the above command
 - Add `export let only=true` to a test in test/e2e to just run that test
 - Add `export let exclude=true` to a test in test/e2e to not run that test
 - To debug a test, with breakpoints:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 ## Tips
 
 - Use `npm run tdd` to compile and re-run tests when a file is modified
-- Use `DEBUG=json2ts npm run tdd` to add logging output to the above command
+- Use `DEBUG=true npm run tdd` to add logging output to the above command
 - Add `export let only=true` to a test in test/e2e to just run that test
 - Add `export let exclude=true` to a test in test/e2e to not run that test
 - To debug a test, with breakpoints:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 ## Tips
 
 - Use `npm run tdd` to compile and re-run tests when a file is modified
-- Use `DEBUG=true npm run tdd` to add logging output to the above command
+- Use `DEBUG=json2ts npm run tdd` to add logging output to the above command
 - Add `export let only=true` to a test in test/e2e to just run that test
 - Add `export let exclude=true` to a test in test/e2e to not run that test
 - To debug a test, with breakpoints:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,7 +77,7 @@ export function error(...messages: any[]) {
 }
 
 export function log(...messages: any[]) {
-  if (process.env.DEBUG) {
+  if (process.env.VERBOSE) {
     console.info(whiteBright.bgCyan('debug'), ...messages)
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,9 +76,8 @@ export function error(...messages: any[]) {
   console.error(whiteBright.bgRedBright('error'), ...messages)
 }
 
-const debugEnabled = process.env.DEBUG !== undefined && process.env.DEBUG.includes('json2ts')
 export function log(...messages: any[]) {
-  if (debugEnabled) {
+  if (process.env.DEBUG) {
     console.info(whiteBright.bgCyan('debug'), ...messages)
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -76,8 +76,9 @@ export function error(...messages: any[]) {
   console.error(whiteBright.bgRedBright('error'), ...messages)
 }
 
+const debugEnabled = process.env.DEBUG !== undefined && process.env.DEBUG.includes('json2ts')
 export function log(...messages: any[]) {
-  if (process.env.DEBUG) {
+  if (debugEnabled) {
     console.info(whiteBright.bgCyan('debug'), ...messages)
   }
 }


### PR DESCRIPTION
The current implementation clashes with https://www.npmjs.com/package/debug causing unexpected terminal output when a user may have been specifying a pattern intended for the `debug` module.

`debug` has nearly 75 million download per month, so quite lot of people could hit this.