### PR TITLE
Refactor typeOfSchema.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "shx": "^0.2.2",
     "tsify": "^3.0.3",
     "tslint": "^5.8.0",
-    "typescript": "^2.6.1"
+    "typescript": "^2.8.0"
   },
   "ava": {
     "files": [

--- a/src/typeOfSchema.ts
+++ b/src/typeOfSchema.ts
@@ -5,6 +5,16 @@ import { JSONSchema, SCHEMA_TYPE } from './types/JSONSchema'
  * Duck types a JSONSchema schema or property to determine which kind of AST node to parse it into.
  */
 export function typeOfSchema(schema: JSONSchema): SCHEMA_TYPE {
+  const oldJudgement = typeOfSchemaOld(schema)
+  const newJudgement = typeOfSchemaNew(schema)
+  if (newJudgement !== oldJudgement) {
+    console.warn(newJudgement, oldJudgement, typeof schema)
+    console.log(schema)
+  }
+  return oldJudgement
+}
+
+function typeOfSchemaOld(schema: JSONSchema): SCHEMA_TYPE {
   if (schema.allOf) return 'ALL_OF'
   if (schema.anyOf) return 'ANY_OF'
   if (schema.oneOf) return 'ONE_OF'
@@ -36,4 +46,68 @@ export function typeOfSchema(schema: JSONSchema): SCHEMA_TYPE {
   if (schema.id) return 'NAMED_SCHEMA'
   if (isPlainObject(schema) && Object.keys(schema).length) return 'UNNAMED_SCHEMA'
   return 'ANY'
+}
+
+type KnownKeys<T> = {
+  [K in keyof T]: string extends K ? never : number extends K ? never : K
+} extends { [_ in keyof T]: infer U }
+  ? U
+  : never
+type Strings<T> = Exclude<T, Exclude<T, string>>
+
+type SchemaIdentifier = (schema: JSONSchema) => SCHEMA_TYPE
+const propertyMap: [KnownKeys<JSONSchema>, SCHEMA_TYPE | SchemaIdentifier][] = [
+  ['allOf', 'ALL_OF'],
+  ['anyOf', 'ANY_OF'],
+  ['oneOf', 'ONE_OF'],
+  ['items', 'TYPED_ARRAY'],
+  [
+    'enum',
+    schema =>
+      schema.hasOwnProperty('tsEnumNames') ? 'NAMED_ENUM' : 'UNNAMED_ENUM'
+  ],
+  ['$ref', 'REFERENCE']
+]
+
+const defaultMap: Record<string, SCHEMA_TYPE | undefined> = {
+  boolean: 'BOOLEAN',
+  number: 'NUMBER',
+  string: 'STRING'
+}
+const anyMoreProps: SchemaIdentifier = schema =>
+  !schema.properties && !isPlainObject(schema)
+    ? 'OBJECT'
+    : defaultMap[typeof schema.default] ||
+      (schema.id
+        ? 'NAMED_SCHEMA'
+        : isPlainObject(schema) && Object.keys(schema).length
+          ? 'UNNAMED_SCHEMA'
+          : 'ANY')
+
+const typeLookup: Record<
+  Strings<JSONSchema['type']>,
+  SCHEMA_TYPE | SchemaIdentifier
+> = {
+  string: 'STRING',
+  number: 'NUMBER',
+  integer: 'NUMBER',
+  boolean: 'BOOLEAN',
+  object: anyMoreProps,
+  array: 'UNTYPED_ARRAY',
+  null: 'NULL',
+  any: 'ANY'
+}
+
+const typeOfSchemaNew = (schema: JSONSchema): SCHEMA_TYPE => {
+  const firstPropertyMatched = propertyMap.find(([key]) =>
+    schema.hasOwnProperty(key)
+  )
+  const val = firstPropertyMatched
+    ? firstPropertyMatched[1]
+    : schema.hasOwnProperty('type') && schema.type
+      ? Array.isArray(schema.type)
+        ? 'UNION'
+        : typeLookup[schema.type]
+      : anyMoreProps
+  return typeof val === 'string' ? val : val(schema)
 }


### PR DESCRIPTION
It benchmarks better, and it is clearer what takes priority over what.
A further performance optimization could be making a left and a right array from `propertyMap` (manually or at module parse time), so instead of
```ts
const firstPropertyMatched = propertyMap.find(([key]) =>
    schema.hasOwnProperty(key)
  )
```
we end up doing
```ts
const firstPropertyIndex = propertyKeys.findIndex(key => schema.hasOwnProperty(key) )
const val = firstPropertyIndex !== -1
    ? propertyValues[firstPropertyIndex]
    : {/* other stuff */}
```



There is currently one difference in undocumented behavior of the function exposed by tests:

When **`schema`** argument passed is literally `[ 'firstName', 'lastName' ]`, the old function returned `'ANY'` while the new returns `'OBJECT'`.
This doesn't actually fail any tests, and might be an error in the test.
I didn't handle this in any special way because it is an incorrect invocation of the function.



TypeScript 2.8 is required to type this code (due to Conditional Types in `KnownKeys`), but that doesn't affect output or anything.