### PR TITLE
eliminate throwing of undefined

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { readFile, writeFile } from 'mz/fs'
 import { resolve } from 'path'
 import stdin = require('stdin')
 import { compile, Options } from './index'
+import { whiteBright } from 'cli-color'
 
 main(minimist(process.argv.slice(2), {
   alias: {
@@ -30,7 +31,7 @@ async function main(argv: minimist.ParsedArgs) {
     const ts = await compile(schema, argIn, argv as Partial<Options>)
     await writeOutput(ts, argOut)
   } catch (e) {
-    process.stderr.write(e.message)
+    console.error(whiteBright.bgRedBright('error'), e)
     process.exit(1)
   }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5,7 +5,8 @@ import { Options } from './'
 import { typeOfSchema } from './typeOfSchema'
 import { AST, hasStandaloneName, T_ANY, T_ANY_ADDITIONAL_PROPERTIES, TInterface, TInterfaceParam, TNamedInterface } from './types/AST'
 import { JSONSchema, JSONSchemaWithDefinitions, SchemaSchema } from './types/JSONSchema'
-import { error, generateName, log } from './utils'
+import { generateName, log } from './utils'
+import { format } from 'util'
 
 export type Processed = Map<JSONSchema | JSONSchema4Type, AST>
 
@@ -142,7 +143,7 @@ function parseNonLiteral(
         type: 'UNION'
       })
     case 'REFERENCE':
-      throw error('Refs should have been resolved by the resolver!', schema)
+      throw Error(format('Refs should have been resolved by the resolver!', schema))
     case 'STRING':
       return set({
         comment: schema.description,
@@ -261,7 +262,7 @@ function newNamedInterface(
     return namedInterface
   }
   // TODO: Generate name if it doesn't have one
-  throw error('Supertype must have standalone name!', namedInterface)
+  throw Error(format('Supertype must have standalone name!', namedInterface))
 }
 
 /**


### PR DESCRIPTION
This patch is related to issue #182. Currently some errors result in undefined values be thrown. This patch eliminates that.

Output before patch:

```
error Refs should have been resolved by the resolver! { definitions: 
   { Something: 
      { id: 'Something',
        title: 'The thing that is some',
        type: 'object',
        required: [Array],
        additionalProperties: false,
        properties: [Object],
        description: '' } },
  description: '',
  required: [],
  additionalProperties: true,
  id: 'Broken',
  title: 'The thing that is some',
  type: 'object',
  properties: 
   { foo: { type: 'string', title: 'the value of bar' },
     bar: { type: 'string', title: 'the value of foo' } },
  '$ref': '#' }
(node:11454) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'message' of undefined
    at /srv/filesystems/upheigie/projects/github.com/bcherny/json-schema-to-typescript/dist/src/cli.js:79:46
    at step (/srv/filesystems/upheigie/projects/github.com/bcherny/json-schema-to-typescript/dist/src/cli.js:33:23)
    at Object.throw (/srv/filesystems/upheigie/projects/github.com/bcherny/json-schema-to-typescript/dist/src/cli.js:14:53)
    at rejected (/srv/filesystems/upheigie/projects/github.com/bcherny/json-schema-to-typescript/dist/src/cli.js:6:65)
    at <anonymous>
(node:11454) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:11454) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

After patch:

```
$ node dist/src/cli.js --unreachableDefinitions=true ~/.local/tmp/broken.json 2>&1 | tee /var/tmp/out.after
error Error: Refs should have been resolved by the resolver! { definitions: 
   { Something: 
      { id: 'Something',
        title: 'The thing that is some',
        type: 'object',
        required: [Array],
        additionalProperties: false,
        properties: [Object],
        description: '' } },
  description: '',
  required: [],
  additionalProperties: true,
  id: 'Broken',
  title: 'The thing that is some',
  type: 'object',
  properties: 
   { foo: { type: 'string', title: 'the value of bar' },
     bar: { type: 'string', title: 'the value of foo' } },
  '$ref': '#' }
    at parseNonLiteral (/home/iwana/projects/github.com/concsys/json-schema-to-typescript/dist/src/parser.js:126:19)
    at parse (/home/iwana/projects/github.com/concsys/json-schema-to-typescript/dist/src/parser.js:38:11)
    at Object.<anonymous> (/home/iwana/projects/github.com/concsys/json-schema-to-typescript/dist/src/index.js:118:104)
    at step (/home/iwana/projects/github.com/concsys/json-schema-to-typescript/dist/src/index.js:56:23)
    at Object.next (/home/iwana/projects/github.com/concsys/json-schema-to-typescript/dist/src/index.js:37:53)
    at fulfilled (/home/iwana/projects/github.com/concsys/json-schema-to-typescript/dist/src/index.js:28:58)
    at <anonymous>
```

