### PR TITLE
Moved unnecessary @types to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,12 +45,8 @@
   },
   "homepage": "https://github.com/bcherny/json-schema-to-typescript#readme",
   "dependencies": {
-    "@types/cli-color": "^0.3.29",
     "@types/json-schema": "^7.0.3",
-    "@types/lodash": "^4.14.121",
-    "@types/minimist": "^1.2.0",
-    "@types/mz": "0.0.32",
-    "@types/node": "^11.10.4",
+    "@types/node": ">=4.5.0",
     "@types/prettier": "^1.16.1",
     "cli-color": "^1.4.0",
     "json-schema-ref-parser": "^6.1.0",
@@ -62,6 +58,10 @@
     "stdin": "0.0.1"
   },
   "devDependencies": {
+    "@types/cli-color": "^0.3.29",
+    "@types/lodash": "^4.14.121",
+    "@types/minimist": "^1.2.0",
+    "@types/mz": "0.0.32",
     "ava": "^1.2.1",
     "browserify": "^16.2.3",
     "browserify-shim": "^3.8.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -348,14 +348,10 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*":
-  version "10.12.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.6.tgz#7fc213c1b811c90fc9a3edb6206742b95d697678"
-
-"@types/node@^11.10.4":
-  version "11.10.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.10.4.tgz#3f5fc4f0f322805f009e00ab35a2ff3d6b778e42"
-  integrity sha512-wa09itaLE8L705aXd8F80jnFpxz3Y1/KRHfKsYL2bPc0XF+wEWu8sR9n5bmeu8Ba1N9z2GRNzm/YdHcghLkLKg==
+"@types/node@*", "@types/node@>=4.5.0":
+  version "11.13.4"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.4.tgz#f83ec3c3e05b174b7241fadeb6688267fe5b22ca"
+  integrity sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==
 
 "@types/prettier@^1.16.1":
   version "1.16.1"


### PR DESCRIPTION
`cli-color`, `lodash`, `minimist` and `mz` are not exported by the library, so consumers don't need to install their types. 

Also changed `@types/node` to `*` to ensure that it is de-duped by the package manage if consumer already has this dependency (in particular older version).

These changes result in a more lightweight installation (`@types` folder used to be 2.2MB, now 594KB).