### PR TITLE
Normalize performance improvement: use isRoot param to set top level ID

### DIFF
--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -116,9 +116,8 @@ rules.set('Normalize schema.items', (schema, _rootSchema, _fileName, options) =>
 
 export function normalize(schema: JSONSchema, filename: string, options: Options): NormalizedJSONSchema {
   const _schema = cloneDeep(schema) as NormalizedJSONSchema
-  const isRoot = true
   rules.forEach((rule, key) => {
-    traverse(_schema, (schema, isRoot) => rule(schema, _schema, filename, options, isRoot), isRoot)
+    traverse(_schema, (schema, isRoot) => rule(schema, _schema, filename, options, isRoot), true)
     log(whiteBright.bgYellow('normalizer'), `Applied rule: "${key}"`)
   })
   return _schema

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -4,7 +4,7 @@ import {JSONSchema, JSONSchemaTypeName, NormalizedJSONSchema} from './types/JSON
 import {escapeBlockComment, justName, log, toSafeString, traverse} from './utils'
 import {Options} from './'
 
-type Rule = (schema: JSONSchema, rootSchema: JSONSchema, fileName: string, options: Options, isRoot?: boolean) => void
+type Rule = (schema: JSONSchema, rootSchema: JSONSchema, fileName: string, options: Options, isRoot: boolean) => void
 const rules = new Map<string, Rule>()
 
 function hasType(schema: JSONSchema, type: JSONSchemaTypeName) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,8 +87,12 @@ function traverseObjectKeys(obj: Record<string, JSONSchema>, callback: (schema: 
 function traverseArray(arr: JSONSchema[], callback: (schema: JSONSchema) => void) {
   arr.forEach(i => traverse(i, callback))
 }
-export function traverse(schema: JSONSchema, callback: (schema: JSONSchema) => void): void {
-  callback(schema)
+export function traverse(
+  schema: JSONSchema,
+  callback: (schema: JSONSchema, isRoot?: boolean) => void,
+  isRoot?: boolean
+): void {
+  callback(schema, isRoot)
 
   if (schema.anyOf) {
     traverseArray(schema.anyOf, callback)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -80,17 +80,17 @@ const BLACKLISTED_KEYS = new Set([
 function traverseObjectKeys(obj: Record<string, JSONSchema>, callback: (schema: JSONSchema, isRoot: boolean) => void) {
   Object.keys(obj).forEach(k => {
     if (obj[k] && typeof obj[k] === 'object' && !Array.isArray(obj[k])) {
-      traverse(obj[k], callback, false)
+      traverse(obj[k], callback)
     }
   })
 }
 function traverseArray(arr: JSONSchema[], callback: (schema: JSONSchema, isRoot: boolean) => void) {
-  arr.forEach(i => traverse(i, callback, false))
+  arr.forEach(i => traverse(i, callback))
 }
 export function traverse(
   schema: JSONSchema,
   callback: (schema: JSONSchema, isRoot: boolean) => void,
-  isRoot: boolean
+  isRoot = false
 ): void {
   callback(schema, isRoot)
 
@@ -110,18 +110,18 @@ export function traverse(
     traverseObjectKeys(schema.patternProperties, callback)
   }
   if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
-    traverse(schema.additionalProperties, callback, false)
+    traverse(schema.additionalProperties, callback)
   }
   if (schema.items) {
     const {items} = schema
     if (Array.isArray(items)) {
       traverseArray(items, callback)
     } else {
-      traverse(items, callback, false)
+      traverse(items, callback)
     }
   }
   if (schema.additionalItems && typeof schema.additionalItems === 'object') {
-    traverse(schema.additionalItems, callback, false)
+    traverse(schema.additionalItems, callback)
   }
   if (schema.dependencies) {
     traverseObjectKeys(schema.dependencies, callback)
@@ -130,7 +130,7 @@ export function traverse(
     traverseObjectKeys(schema.definitions, callback)
   }
   if (schema.not) {
-    traverse(schema.not, callback, false)
+    traverse(schema.not, callback)
   }
 
   // technically you can put definitions on any key

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,20 +77,20 @@ const BLACKLISTED_KEYS = new Set([
   'oneOf',
   'not'
 ])
-function traverseObjectKeys(obj: Record<string, JSONSchema>, callback: (schema: JSONSchema) => void) {
+function traverseObjectKeys(obj: Record<string, JSONSchema>, callback: (schema: JSONSchema, isRoot: boolean) => void) {
   Object.keys(obj).forEach(k => {
     if (obj[k] && typeof obj[k] === 'object' && !Array.isArray(obj[k])) {
-      traverse(obj[k], callback)
+      traverse(obj[k], callback, false)
     }
   })
 }
-function traverseArray(arr: JSONSchema[], callback: (schema: JSONSchema) => void) {
-  arr.forEach(i => traverse(i, callback))
+function traverseArray(arr: JSONSchema[], callback: (schema: JSONSchema, isRoot: boolean) => void) {
+  arr.forEach(i => traverse(i, callback, false))
 }
 export function traverse(
   schema: JSONSchema,
-  callback: (schema: JSONSchema, isRoot?: boolean) => void,
-  isRoot?: boolean
+  callback: (schema: JSONSchema, isRoot: boolean) => void,
+  isRoot: boolean
 ): void {
   callback(schema, isRoot)
 
@@ -110,18 +110,18 @@ export function traverse(
     traverseObjectKeys(schema.patternProperties, callback)
   }
   if (schema.additionalProperties && typeof schema.additionalProperties === 'object') {
-    traverse(schema.additionalProperties, callback)
+    traverse(schema.additionalProperties, callback, false)
   }
   if (schema.items) {
     const {items} = schema
     if (Array.isArray(items)) {
       traverseArray(items, callback)
     } else {
-      traverse(items, callback)
+      traverse(items, callback, false)
     }
   }
   if (schema.additionalItems && typeof schema.additionalItems === 'object') {
-    traverse(schema.additionalItems, callback)
+    traverse(schema.additionalItems, callback, false)
   }
   if (schema.dependencies) {
     traverseObjectKeys(schema.dependencies, callback)
@@ -130,7 +130,7 @@ export function traverse(
     traverseObjectKeys(schema.definitions, callback)
   }
   if (schema.not) {
-    traverse(schema.not, callback)
+    traverse(schema.not, callback, false)
   }
 
   // technically you can put definitions on any key


### PR DESCRIPTION
Implemented fix proposed in this [issue](https://github.com/bcherny/json-schema-to-typescript/issues/286#issuecomment-622980228) 
- prior use of stringify to check root was very slow. see the issue for more details.