### PR TITLE
make types nullable

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -186,7 +186,7 @@ function generateRawType(ast: AST, options: Options): string {
         return type.endsWith('"') ? '(' + type + ')[]' : type + '[]'
       })()
     case 'BOOLEAN':
-      return 'boolean'
+      return 'boolean' + (ast.isNullable? ' | null' : '')
     case 'INTERFACE':
       return generateInterface(ast, options)
     case 'INTERSECTION':
@@ -194,15 +194,15 @@ function generateRawType(ast: AST, options: Options): string {
     case 'LITERAL':
       return JSON.stringify(ast.params)
     case 'NUMBER':
-      return 'number'
+      return 'number' + (ast.isNullable? ' | null' : '')
     case 'NULL':
       return 'null'
     case 'OBJECT':
-      return 'object'
+      return 'object' + (ast.isNullable? ' | null' : '')
     case 'REFERENCE':
       return ast.params
     case 'STRING':
-      return 'string'
+      return 'string' + (ast.isNullable? ' | null' : '')
     case 'TUPLE':
       return (() => {
         const minItems = ast.minItems
@@ -284,7 +284,7 @@ function generateRawType(ast: AST, options: Options): string {
     case 'UNION':
       return generateSetOperation(ast, options)
     case 'CUSTOM_TYPE':
-      return ast.params
+      return ast.params + (ast.isNullable? ' | null' : '')
   }
 }
 
@@ -293,6 +293,9 @@ function generateRawType(ast: AST, options: Options): string {
  */
 function generateSetOperation(ast: TIntersection | TUnion, options: Options): string {
   const members = (ast as TUnion).params.map(_ => generateType(_, options))
+  if (ast.type === 'UNION' && ast.isNullable) {
+    members.push('null')
+  }
   const separator = ast.type === 'UNION' ? '|' : '&'
   return members.length === 1 ? members[0] : '(' + members.join(' ' + separator + ' ') + ')'
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -186,7 +186,7 @@ function generateRawType(ast: AST, options: Options): string {
         return type.endsWith('"') ? '(' + type + ')[]' : type + '[]'
       })()
     case 'BOOLEAN':
-      return 'boolean' + (ast.isNullable? ' | null' : '')
+      return 'boolean' + (ast.isNullable ? ' | null' : '')
     case 'INTERFACE':
       return generateInterface(ast, options)
     case 'INTERSECTION':
@@ -194,15 +194,15 @@ function generateRawType(ast: AST, options: Options): string {
     case 'LITERAL':
       return JSON.stringify(ast.params)
     case 'NUMBER':
-      return 'number' + (ast.isNullable? ' | null' : '')
+      return 'number' + (ast.isNullable ? ' | null' : '')
     case 'NULL':
       return 'null'
     case 'OBJECT':
-      return 'object' + (ast.isNullable? ' | null' : '')
+      return 'object' + (ast.isNullable ? ' | null' : '')
     case 'REFERENCE':
       return ast.params
     case 'STRING':
-      return 'string' + (ast.isNullable? ' | null' : '')
+      return 'string' + (ast.isNullable ? ' | null' : '')
     case 'TUPLE':
       return (() => {
         const minItems = ast.minItems
@@ -284,7 +284,7 @@ function generateRawType(ast: AST, options: Options): string {
     case 'UNION':
       return generateSetOperation(ast, options)
     case 'CUSTOM_TYPE':
-      return ast.params + (ast.isNullable? ' | null' : '')
+      return ast.params + (ast.isNullable ? ' | null' : '')
   }
 }
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -104,6 +104,7 @@ function parseNonLiteral(
     case 'ANY_OF':
       return set({
         comment: schema.description,
+        isNullable: !!schema.nullable,
         keyName,
         params: schema.anyOf!.map(_ => parse(_, options, rootSchema, undefined, true, processed, usedNames)),
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames),
@@ -112,6 +113,7 @@ function parseNonLiteral(
     case 'BOOLEAN':
       return set({
         comment: schema.description,
+        isNullable: !!schema.nullable,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames),
         type: 'BOOLEAN'
@@ -119,6 +121,7 @@ function parseNonLiteral(
     case 'CUSTOM_TYPE':
       return set({
         comment: schema.description,
+        isNullable: !!schema.nullable,
         keyName,
         params: schema.tsType!,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames),
@@ -147,6 +150,7 @@ function parseNonLiteral(
     case 'NUMBER':
       return set({
         comment: schema.description,
+        isNullable: !!schema.nullable,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames),
         type: 'NUMBER'
@@ -154,6 +158,7 @@ function parseNonLiteral(
     case 'OBJECT':
       return set({
         comment: schema.description,
+        isNullable: !!schema.nullable,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames),
         type: 'OBJECT'
@@ -161,6 +166,7 @@ function parseNonLiteral(
     case 'ONE_OF':
       return set({
         comment: schema.description,
+        isNullable: !!schema.nullable,
         keyName,
         params: schema.oneOf!.map(_ => parse(_, options, rootSchema, undefined, true, processed, usedNames)),
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames),
@@ -171,6 +177,7 @@ function parseNonLiteral(
     case 'STRING':
       return set({
         comment: schema.description,
+        isNullable: !!schema.nullable,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames),
         type: 'STRING'
@@ -218,6 +225,7 @@ function parseNonLiteral(
     case 'UNION':
       return set({
         comment: schema.description,
+        isNullable: !!schema.nullable,
         keyName,
         params: (schema.type as JSONSchema4TypeName[]).map(_ =>
           parse({...schema, type: _}, options, rootSchema, undefined, true, processed, usedNames)
@@ -228,6 +236,7 @@ function parseNonLiteral(
     case 'UNNAMED_ENUM':
       return set({
         comment: schema.description,
+        isNullable: !!schema.nullable,
         keyName,
         params: schema.enum!.map(_ => parse(_, options, rootSchema, undefined, false, processed, usedNames)),
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames),

--- a/src/types/AST.ts
+++ b/src/types/AST.ts
@@ -37,6 +37,7 @@ export interface TArray extends AbstractAST {
 }
 
 export interface TBoolean extends AbstractAST {
+  isNullable: boolean
   type: 'BOOLEAN'
 }
 
@@ -83,6 +84,7 @@ export interface TLiteral extends AbstractAST {
 }
 
 export interface TNumber extends AbstractAST {
+  isNullable: boolean
   type: 'NUMBER'
 }
 
@@ -91,6 +93,7 @@ export interface TNull extends AbstractAST {
 }
 
 export interface TObject extends AbstractAST {
+  isNullable: boolean
   type: 'OBJECT'
 }
 
@@ -100,6 +103,7 @@ export interface TReference extends AbstractAST {
 }
 
 export interface TString extends AbstractAST {
+  isNullable: boolean
   type: 'STRING'
 }
 
@@ -112,11 +116,13 @@ export interface TTuple extends AbstractAST {
 }
 
 export interface TUnion extends AbstractAST {
+  isNullable: boolean
   type: 'UNION'
   params: AST[]
 }
 
 export interface TCustomType extends AbstractAST {
+  isNullable: boolean
   type: 'CUSTOM_TYPE'
   params: string
 }


### PR DESCRIPTION
Hey.
Was using your typescript compiler for a while and noticed there is no support for the nullable flag. I tried to implement a solution. I hope it satisfies you enough to make it into the main repository. Would be pleased to use this feature in future.
Ps. I implemented a solution that works for me. I cannot promise every possible nullable flag will work with those changed. The most important ones should be covered.
Supported are all basic types and unnamed enums. Named enums, objects and Interfaces shouldn`t be covered.

Regards