### PR TITLE
Support schema module imports

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -116,6 +116,12 @@ function parseNonLiteral(
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames),
         type: 'BOOLEAN'
       })
+    case 'CUSTOM_MODULE':
+      return set({
+        params: schema.tsType!,
+        module: schema.tsModule!,
+        type: 'CUSTOM_MODULE'
+      })
     case 'CUSTOM_TYPE':
       return set({
         comment: schema.description,

--- a/src/typeOfSchema.ts
+++ b/src/typeOfSchema.ts
@@ -5,6 +5,7 @@ import {JSONSchema, SCHEMA_TYPE} from './types/JSONSchema'
  * Duck types a JSONSchema schema or property to determine which kind of AST node to parse it into.
  */
 export function typeOfSchema(schema: JSONSchema): SCHEMA_TYPE {
+  if (schema.tsModule) return 'CUSTOM_MODULE'
   if (schema.tsType) return 'CUSTOM_TYPE'
   if (schema.allOf) return 'ALL_OF'
   if (schema.anyOf) return 'ANY_OF'

--- a/src/types/AST.ts
+++ b/src/types/AST.ts
@@ -4,7 +4,7 @@ export type AST_TYPE = AST['type']
 
 export type AST = TAny | TArray | TBoolean | TEnum | TInterface | TNamedInterface
   | TIntersection | TLiteral | TNumber | TNull | TObject | TReference
-  | TString | TTuple | TUnion | TCustomType
+  | TString | TTuple | TUnion | TCustomType | TCustomModule
 
 export interface AbstractAST {
   comment?: string
@@ -118,6 +118,12 @@ export interface TUnion extends AbstractAST {
 
 export interface TCustomType extends AbstractAST {
   type: 'CUSTOM_TYPE'
+  params: string
+}
+
+export interface TCustomModule extends AbstractAST {
+  type: 'CUSTOM_MODULE'
+  module: string
   params: string
 }
 

--- a/src/types/JSONSchema.ts
+++ b/src/types/JSONSchema.ts
@@ -3,7 +3,7 @@ import { JSONSchema4, JSONSchema4TypeName } from 'json-schema'
 export type SCHEMA_TYPE = 'ALL_OF' | 'UNNAMED_SCHEMA' | 'ANY' | 'ANY_OF'
   | 'BOOLEAN' | 'NAMED_ENUM' | 'NAMED_SCHEMA' | 'NULL' | 'NUMBER' | 'STRING'
   | 'OBJECT' | 'ONE_OF' | 'TYPED_ARRAY' | 'REFERENCE' | 'UNION' | 'UNNAMED_ENUM'
-  | 'UNTYPED_ARRAY' | 'CUSTOM_TYPE'
+  | 'UNTYPED_ARRAY' | 'CUSTOM_TYPE' | 'CUSTOM_MODULE'
 
 export type JSONSchemaTypeName = JSONSchema4TypeName
 


### PR DESCRIPTION
I added support for a `tsModule` property. When specified, this adds an `import` declaration at the top of the generated file. We needed this feature so that the exported types that reference other schemas could be imported and not inline duplicated. My main motivation was to unblock our team and reduce error-prone manual steps when generating types. I'm providing this PR to open some discussion and solicit ideas before taking it any further (as there are multiple ways to solve this problem).

Usage:

    ...
    someColourField: {$ref: 'https://myorg.com/schemas/colours.json', tsModule: './colours', tsType: 'Colour' },
    ...


will produce:


    import {Colour} from './colours';
    ...
    export interface MyObject {
        ...
        someColourField: Colour;
        ...
    }

Import statements are de-duped, however it doesn't support importing multiple types from the same module; we didn't have this need and generally only reference the single top-level schema object exported from a given module.

All feedback welcome!