### PR TITLE
doc: fix link to extends

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ json2ts -i foo.json -o foo.d.ts --style.singleQuote --no-style.semi
 - [x] `minItems` ([eg](https://github.com/tdegrunt/jsonschema/blob/67c0e27ce9542efde0bf43dc1b2a95dd87df43c3/examples/all.js#L165))
 - [x] `additionalProperties` of type
 - [x] `patternProperties` (partial support)
-- [x] [`extends`](https://github.com/json-schema/json-schema/wiki/Extends)
+- [x] [`extends`](https://github.com/json-schema/json-schema/wiki/Extends/014e3cd8692250baad70c361dd81f6119ad0f696)
 - [x] `required` properties on objects ([eg](https://github.com/tdegrunt/jsonschema/blob/67c0e27ce9542efde0bf43dc1b2a95dd87df43c3/examples/all.js#L130))
 - [ ] `validateRequired` ([eg](https://github.com/tdegrunt/jsonschema/blob/67c0e27ce9542efde0bf43dc1b2a95dd87df43c3/examples/all.js#L124))
 - [x] literal objects in enum ([eg](https://github.com/tdegrunt/jsonschema/blob/67c0e27ce9542efde0bf43dc1b2a95dd87df43c3/examples/all.js#L236))


### PR DESCRIPTION
Alternatively, we could link to the changelog where it's been removed: https://github.com/json-schema/json-schema/wiki/Change-Log:-draft-03-to-draft-04#extends