### PR TITLE
Allow to install package from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "node": ">=10.0.0"
   },
   "scripts": {
+    "prepare": "npm run build",
     "build": "npm run clean && mkdir dist && npm run build:browser && npm run build:server",
     "build:browser": "browserify src/index.ts -s jstt -p tsify > dist/bundle.js",
     "build:server": "tsc -d",


### PR DESCRIPTION
This adds 'prepare' script that npm/yarn will run upon package
installation in node_modules. Previously installation from GitHub would
fail because dist is not committed to the repository but
'bin'->'json2ts' refers to files in it ('dist/src/cli.js') which
therefore fails the installation.