### PR TITLE
fix: Move @types/prettier to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "homepage": "https://github.com/bcherny/json-schema-to-typescript#readme",
   "dependencies": {
     "@types/json-schema": "^7.0.4",
+    "@types/prettier": "2.0.0",
     "cli-color": "^2.0.0",
     "glob": "^7.1.6",
     "glob-promise": "^3.4.0",
@@ -69,7 +70,6 @@
     "@types/mkdirp": "^1.0.0",
     "@types/mz": "^2.7.0",
     "@types/node": "^13.13.4",
-    "@types/prettier": "2.0.0",
     "@types/rimraf": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^2.30.0",
     "@typescript-eslint/parser": "^2.30.0",


### PR DESCRIPTION
`src/index.ts` imports the `Options` type from [@types/prettier](https://www.npmjs.com/package/@types/prettier) as `PrettierOptions`, and re-exports it as part of the package signature. Because of this, any TypeScript project that installs json-schema-to-typescript as a dependency or devDependency (e.g. to run it programmatically) will attempt to locate @types/prettier--but run into trouble, because @types/prettier is not installed.

To avoid this, @types/prettier should also be pulled in as a dependency of json-schema-to-typescript.

This fixes a possible oversight made in 1a91ef007cd7262331e81edc6a809777f5f38e4f

Note: In the meantime, downstream projects can manually pull in @types/prettier as their own dependencies.