### PR TITLE
[Feat] Memoize `getDefinition` parser function

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,5 +1,5 @@
 import {JSONSchema4Type, JSONSchema4TypeName} from 'json-schema'
-import {findKey, includes, isPlainObject, map, omit} from 'lodash'
+import {findKey, includes, isPlainObject, map, memoize, omit} from 'lodash'
 import {format} from 'util'
 import {Options} from './'
 import {typesOfSchema} from './typesOfSchema'
@@ -119,7 +119,7 @@ function parseNonLiteral(
   processed: Processed,
   usedNames: UsedNames
 ): AST {
-  const definitions = getDefinitions(getRootSchema(schema as any)) // TODO
+  const definitions = getDefinitionsMemoized(getRootSchema(schema as any)) // TODO
   const keyNameFromDefinition = findKey(definitions, _ => _ === schema)
 
   switch (type) {
@@ -433,9 +433,6 @@ via the \`definition\` "${key}".`
 
 type Definitions = {[k: string]: LinkedJSONSchema}
 
-/**
- * TODO: Memoize
- */
 function getDefinitions(
   schema: LinkedJSONSchema,
   isSchema = true,
@@ -468,6 +465,8 @@ function getDefinitions(
   }
   return {}
 }
+
+const getDefinitionsMemoized = memoize(getDefinitions)
 
 /**
  * TODO: Reduce rate of false positives


### PR DESCRIPTION
I've been working on schemas for Github webhook events with the goal of generating types from the schemas - we recently merged the initial schemas, and so I've gotten to the point of actually generating the types from the `schema.json` generated by running `npm run build:schema` on [this pr](https://github.com/octokit/webhooks/pull/252).

The `schema.json` is quite large - just shy of 30000 lines, and currently it takes ~120 seconds to build the `.d.ts` file.
While I know this is to be expected when running large schemas, I did some basic poking around and found that the bulk of the bottleneck is in the `getDefinitions` parser method.

That method had a jsdoc block with the comment "TODO: Memoize" so on a whim I decided to see how fast it'd be if I did just that.

Turns out it'll be 96.4% times faster, taking the time from ~120 seconds down to *~3 seconds* while still generating an identical schema.