### PR TITLE
fix: adjust type to remove need for `@types/lodash`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "homepage": "https://github.com/bcherny/json-schema-to-typescript#readme",
   "dependencies": {
+    "@types/lodash": "^4.14.168",
     "@types/json-schema": "^7.0.6",
     "@types/prettier": "^2.1.5",
     "cli-color": "^2.0.0",
@@ -65,7 +66,6 @@
     "@types/cli-color": "^2.0.0",
     "@types/glob": "^7.1.3",
     "@types/is-glob": "^4.0.1",
-    "@types/lodash": "^4.14.165",
     "@types/minimist": "^1.2.1",
     "@types/mkdirp": "^1.0.1",
     "@types/mz": "^2.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -116,10 +116,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
-"@types/lodash@^4.14.165":
-  version "4.14.165"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
-  integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
+"@types/lodash@^4.14.168":
+  version "4.14.168"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.168.tgz#fe24632e79b7ade3f132891afff86caa5e5ce008"
+  integrity sha512-oVfRvqHV/V6D1yifJbVRU3TMp8OT6o6BG+U9MkwuJ3U8/CsDHvalRpsxBqivn71ztOFZBTfJMvETbqHiaNSj7Q==
 
 "@types/minimatch@*":
   version "3.0.3"


### PR DESCRIPTION
Currently TS errors for this package if `@types/lodash` is not installed:

```
node_modules/json-schema-to-typescript/dist/src/types/JSONSchema.d.ts:1:23 - error TS2688: Cannot find type definition file for 'lodash'.

1 /// <reference types="lodash" />
                        ~~~~~~

node_modules/json-schema-to-typescript/dist/src/types/JSONSchema.d.ts:86:95 - error TS7016: Could not find a declaration file for module 'lodash'. '/c/Users/G-Rath/workspace/projects-oss/webhooks/node_modules/json-schema-to-typescript/node_modules/lodash/lodash.js'
 implicitly has an 'any' type.
  Try `npm i --save-dev @types/lodash` if it exists or add a new declaration (.d.ts) file containing `declare module 'lodash';`

86 export declare const getRootSchema: ((schema: LinkedJSONSchema) => LinkedJSONSchema) & import("lodash").MemoizedFunction;
```

I actually thought this was because of #361 but it's not - not sure why it didn't error in the past on the same project.

Originally I was going to add `@types/lodash` to `dependencies`, but realised I could explicitly type the export to make it not needed.