### PR TITLE
chore: update `.npmignore` to exclude misc files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 .idea
 .vscode
 npm-debug.log
+yarn-error.log
 node_modules
 *.map
 example
@@ -11,3 +12,5 @@ circle.yml
 ARCHITECTURE.md
 CONTRIBUTING.md
 .editorconfig
+package-lock.json
+yarn.lock


### PR DESCRIPTION
The latest release (10.1.3) included a few misc files:

```
❯ npx npm@7 diff --diff json-schema-to-typescript@10.1.2 --diff json-schema-to-typescript@10.1.3 --diff-name-only
npx: installed 254 in 13.455s
dist/src/cli.js
package.json
yarn-error.log
package-lock.json
```