### PR TITLE
[Docs] Quote example glob to avoid shell expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ json2ts foo.json foo.d.ts
 json2ts --input foo.json --output foo.d.ts
 # or
 json2ts -i foo.json -o foo.d.ts
-# or
-json2ts -i schemas/**/*.json
+# or (quote globs so that your shell doesn't expand them)
+json2ts -i 'schemas/**/*.json'
 # or
 json2ts -i schemas/ -o types/
 ```


### PR DESCRIPTION
Hi, first of all, I love this project, it's made my projects a lot cleaner :smile:.

I encountered an issue with my shell expanding the glob, and overwriting some of my existing schemas, so I'd thought I'd update the documentation so it hopefully doesn't happen to anyone else (especially for those unfamiliar with bash).

In most shells (e.g. bash / sh), passing an unquoted glob, such as:  `json2ts -i schemas/**/*.json`, would cause the shell to expand the glob, equivalent to:

```bash
json2ts -i schemas/schema1/schema.json schemas/schema2/schema.json schemas/schema3/schema.json schemas/schema4/schema.json # ...
```

This would then cause ONLY the schema `schemas/schema2/schema.json` to be read and it would be written to `schemas/schema3/schema.json`, due to the following lines:
https://github.com/bcherny/json-schema-to-typescript/blob/eaac3684045976e0726a7fc1909d211b88dfc9f4/src/cli.ts#L29-L30

Quoting the glob will pass the string to `json2ts` correctly, and allow it to handle globbing.