### PR TITLE
Replace dubious dependency `stdin` with `get-stdin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@types/lodash": "^4.14.168",
     "@types/prettier": "^2.1.5",
     "cli-color": "^2.0.0",
+    "get-stdin": "^8.0.0",
     "glob": "^7.1.6",
     "glob-promise": "^3.4.0",
     "is-glob": "^4.0.1",
@@ -59,8 +60,7 @@
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.4",
     "mz": "^2.7.0",
-    "prettier": "^2.2.0",
-    "stdin": "0.0.1"
+    "prettier": "^2.2.0"
   },
   "devDependencies": {
     "@types/cli-color": "^2.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
 import minimist = require('minimist')
+import getStdin from 'get-stdin'
 import {readFile, writeFile, existsSync, lstatSync, readdirSync} from 'mz/fs'
 import * as mkdirp from 'mkdirp'
 import glob from 'glob-promise'
 import isGlob = require('is-glob')
 import {join, resolve, dirname, basename} from 'path'
-import stdin = require('stdin')
 import {compile, Options} from './index'
 import {pathTransform, error} from './utils'
 
@@ -131,7 +131,7 @@ function getPaths(path: string, paths: string[] = []) {
 
 function readInput(argIn?: string) {
   if (!argIn) {
-    return new Promise(stdin)
+    return getStdin()
   }
   return readFile(resolve(process.cwd(), argIn), 'utf-8')
 }

--- a/types/stdin.d.ts
+++ b/types/stdin.d.ts
@@ -1,4 +1,0 @@
-declare module 'stdin' {
-  export = stdin
-  function stdin(fn: (str: string) => any): void
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1807,6 +1807,11 @@ get-stdin@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
+get-stdin@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
+  integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
+
 get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -3504,11 +3509,6 @@ stack-utils@^2.0.3:
   integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
   dependencies:
     escape-string-regexp "^2.0.0"
-
-stdin@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/stdin/-/stdin-0.0.1.tgz#d3041981aaec3dfdbc77a1b38d6372e38f5fb71e"
-  integrity sha1-0wQZgarsPf28d6GzjWNy449ftx4=
 
 stream-browserify@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
* 'stdin' is a package consisting in one commit 8 years ago. There is no support,
there is no community, and it is not even easy to find the source code (you have
to download the tarball using the link from the yarn.lock, you will not find the
repository elsewhere)
* In contrast, `get-stdin` has active support and is more used by two orders of
magnitude
* I firmly believe that the world will be a better place when packages like `stdin`
slowly disappear from our dependency trees

PS: I love your package, keep it up!