### PR TITLE
feat: Reduce install size

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,12 @@
   "bin": {
     "json2ts": "dist/src/cli.js"
   },
+  "files": [
+    "dist/src/",
+    "package.json",
+    "CHANGELOG.md",
+    "README.md"
+  ],
   "typings": "dist/src/index.d.ts",
   "engines": {
     "node": ">=10.0.0"


### PR DESCRIPTION
This patch uses the `files` key in package.json to restrict what is published. This will make the install faster / smaller, and also prevent any strangeness with lingering configs (potentially causing https://github.com/bcherny/json-schema-to-typescript/issues/350)