### PR TITLE
prevent infinite recursion when validating schemas

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,17 +20,17 @@ export function crawl(
   obj: any,
   fn: (value: object, key?: string) => void,
   key?: string, // internal
-  seen = new WeakMap<object, number>() // internal
+  seen = new Set<object>() // internal
 ): void {
   if (!seen.has(obj)) {
     if (isPlainObject(obj)) {
-      seen.set(obj, 1)
+      seen.add(obj)
       for (const key of Object.keys(obj)) {
         crawl(obj[key], fn, key, seen)
       }
       fn(obj, key)
     } else if (Array.isArray(obj)) {
-      seen.set(obj, 1)
+      seen.add(obj)
       for (const el of obj) {
         crawl(el, fn, key, seen)
       }

--- a/src/validator.ts
+++ b/src/validator.ts
@@ -1,5 +1,5 @@
 import {JSONSchema} from './types/JSONSchema'
-import {mapDeep} from './utils'
+import {crawl} from './utils'
 
 type Rule = (schema: JSONSchema) => boolean | void
 const rules = new Map<string, Rule>()
@@ -40,11 +40,10 @@ rules.set('When minItems exists, minItems >= 0', schema => {
 export function validate(schema: JSONSchema, filename: string): string[] {
   const errors: string[] = []
   rules.forEach((rule, ruleName) => {
-    mapDeep(schema, (schema, key) => {
+    crawl(schema, (schema, key) => {
       if (rule(schema) === false) {
         errors.push(`Error at key "${key}" in file "${filename}": ${ruleName}`)
       }
-      return schema
     })
   })
   return errors

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,5 +1,5 @@
 import {serial as test} from 'ava'
-import {pathTransform, generateName} from '../src/utils'
+import {crawl, pathTransform, generateName} from '../src/utils'
 
 export function run() {
   test('pathTransform', t => {
@@ -20,4 +20,40 @@ export function run() {
     t.is(generateName('a', usedNames), 'A2')
     t.is(generateName('a', usedNames), 'A3')
   })
+  test('crawl', t => {
+    const schema1 = {
+      type: 'object',
+      properties: {
+        prop1: {enum: [1, 2, 3]},
+        prop2: {
+          oneOf: [{type: 'string'}, {type: 'number'}]
+        },
+        prop3: null as unknown
+      }
+    }
+    // circular reference will trigger "Maximum call stack size exceeded" if cycle is not detected
+    schema1.properties.prop3 = schema1
+    const fn1 = spy()
+    crawl(schema1, fn1)
+    t.is(fn1.calls.length, 6)
+    // only invokes fn on objects, not scalars, not arrays
+    t.is(fn1.calls[0][0], schema1.properties.prop1)
+    // crawls arrays
+    t.is(fn1.calls[1][0], schema1.properties.prop2.oneOf[0])
+    t.is(fn1.calls[2][0], schema1.properties.prop2.oneOf[1])
+    t.is(fn1.calls[3][0], schema1.properties.prop2)
+    // skips prop3 as cycle is detected
+    // crawl back up the stack
+    t.is(fn1.calls[4][0], schema1.properties)
+    t.is(fn1.calls[5][0], schema1)
+  })
+}
+
+function spy() {
+  const calls: unknown[][] = []
+  const fn = (...args: unknown[]) => {
+    calls.push(args)
+  }
+  fn.calls = calls
+  return fn
 }


### PR DESCRIPTION
**The Problem:**
Summary: 
Infinite recursion is possible in src/utils.ts:mapDeep()
This will fix a few cases of "Uncaught RangeError: Maximum call stack size exceeded"

Detail:
Let's say I define a schema like this:
```javascript
const ListNode = {
  type: 'object',
  properties: {
    value: {type: 'string'},
    next: {$ref: '#'} // Circular reference
  }
}

// If I call compile() twice on the same schema object (with different options, for example)
import {compile} from 'json-schema-to-typescript'
const prettyContent = await compile(ListNode)
// The first call is fine

// But notice the ListNode object was modified (see $RefParser.dereference)
console.log(ListNode)
//{
//  type: 'object',
//  properties: { value: {type: 'string'}, next: [Circular *1] }
//}

const uglyContent = await compile(ListNode, {format: false})
// Uncaught RangeError: Maximum call stack size exceeded
// Uh-oh! There's infinite recursion happening.

// And of course I don't actually have to call compile() twice.
// I could just as well define my schema like this in the first place:
ListNode.properties.next = ListNode
```
**The Solution:**
Summary:
To fix this we can modify the recursive function in question to track seen objects and return early if one is seen second time (or more).

Detail:
**replace src/utils.ts:mapDeep() with crawl()**
- considering where mapDeep() is used, mutation is not necessary so we can remove the use of lodash's mapValues() and just iterate over Object.keys(obj)

**use a Set to detect reference cycles**
- it's fast and has broad browser support which includes IE11

**Final note:** Unfortunately json-schema-ref-parser has the exact same problem so we'll need to wait for https://github.com/APIDevTools/json-schema-ref-parser/pull/231 to merge before this is really solved.
