### PR TITLE
write JSDoc tags for unkown properties

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -4,6 +4,7 @@ import {
   AST,
   ASTWithStandaloneName,
   hasComment,
+  hasJsdoc,
   hasStandaloneName,
   T_ANY,
   TArray,
@@ -308,6 +309,7 @@ function generateInterface(ast: TInterface, options: Options): string {
       .map(
         ([isRequired, keyName, ast, type]) =>
           (hasComment(ast) && !ast.standaloneName ? generateComment(ast.comment) + '\n' : '') +
+          (hasJsdoc(ast) && !ast.standaloneName ? generateJSDoc(ast.jsdoc) + '\n' : '') +
           escapeKeyName(keyName) +
           (isRequired ? '' : '?') +
           ': ' +
@@ -322,10 +324,14 @@ function generateInterface(ast: TInterface, options: Options): string {
 function generateComment(comment: string): string {
   return ['/**', ...comment.split('\n').map(_ => ' * ' + _), ' */'].join('\n')
 }
+function generateJSDoc(jsdoc: Record<string, any>): string {
+  return ['/**', ...Object.entries(jsdoc).map(([k, v])=> `* @${k} ${v}`), ' */'].join('\n')
+}
 
 function generateStandaloneEnum(ast: TEnum, options: Options): string {
   return (
     (hasComment(ast) ? generateComment(ast.comment) + '\n' : '') +
+    (hasJsdoc(ast) ? generateJSDoc(ast.jsdoc) + '\n' : '') +
     'export ' +
     (options.enableConstEnums ? 'const ' : '') +
     `enum ${toSafeString(ast.standaloneName)} {` +
@@ -339,6 +345,7 @@ function generateStandaloneEnum(ast: TEnum, options: Options): string {
 function generateStandaloneInterface(ast: TNamedInterface, options: Options): string {
   return (
     (hasComment(ast) ? generateComment(ast.comment) + '\n' : '') +
+    (hasJsdoc(ast) ? generateJSDoc(ast.jsdoc) + '\n' : '') +
     `export interface ${toSafeString(ast.standaloneName)} ` +
     (ast.superTypes.length > 0
       ? `extends ${ast.superTypes.map(superType => toSafeString(superType.standaloneName)).join(', ')} `
@@ -350,6 +357,7 @@ function generateStandaloneInterface(ast: TNamedInterface, options: Options): st
 function generateStandaloneType(ast: ASTWithStandaloneName, options: Options): string {
   return (
     (hasComment(ast) ? generateComment(ast.comment) + '\n' : '') +
+    (hasJsdoc(ast) ? generateJSDoc(ast.jsdoc) + '\n' : '') +
     `export type ${toSafeString(ast.standaloneName)} = ${generateType(
       omit<AST>(ast, 'standaloneName') as AST /* TODO */,
       options

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -325,7 +325,7 @@ function generateComment(comment: string): string {
   return ['/**', ...comment.split('\n').map(_ => ' * ' + _), ' */'].join('\n')
 }
 function generateJSDoc(jsdoc: Record<string, any>): string {
-  return ['/**', ...Object.entries(jsdoc).map(([k, v])=> `* @${k} ${v}`), ' */'].join('\n')
+  return ['/**', ...Object.entries(jsdoc).map(([k, v])=> `* @${k} ${JSON.stringify(v)}`), ' */'].join('\n')
 }
 
 function generateStandaloneEnum(ast: TEnum, options: Options): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,10 @@ export interface Options {
    */
   unknownAny: boolean
   /**
+   * JSDoc tags to parse from the schema. Will be prepended to each generated type in the comment block (as `@tag [tagValue]`).
+   */ 
+  jsdocTags: string[]
+  /**
    * [$RefParser](https://github.com/BigstickCarpet/json-schema-ref-parser) Options, used when resolving `$ref`s
    */
   $refOptions: $RefOptions
@@ -90,7 +94,8 @@ export const DEFAULT_OPTIONS: Options = {
     useTabs: false
   },
   unreachableDefinitions: false,
-  unknownAny: true
+  unknownAny: true,
+  jsdocTags: [],
 }
 
 export function compileFromFile(filename: string, options: Partial<Options> = DEFAULT_OPTIONS): Promise<string> {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -121,7 +121,7 @@ function parseNonLiteral(
 ): AST {
   const definitions = getDefinitionsMemoized(getRootSchema(schema as any)) // TODO
   const keyNameFromDefinition = findKey(definitions, _ => _ === schema)
-  const jsdoc: Record<string, any> = options.jsdocTags.map(prop => [prop, schema[prop]]).reduce((acc, [key, val]) => (val !== undefined ? { ...acc, [key]: val } : acc), {});
+  const jsdoc = parseTags(schema, options.jsdocTags);
   const jsdocOrComment = isEmpty(jsdoc) ? { comment: schema.description } : { jsdoc: jsdoc };
 
   switch (type) {
@@ -308,6 +308,10 @@ function standaloneName(
   }
 }
 
+function parseTags(schema: { [key: string]: any }, tags: string[]): { [key: string]: any } {
+  return tags.map(prop => [prop, schema[prop]]).reduce((acc, [key, val]) => (val !== undefined ? { ...acc, [key]: val } : acc), {});
+}
+
 function newInterface(
   schema: SchemaSchema,
   options: Options,
@@ -317,7 +321,7 @@ function newInterface(
   keyNameFromDefinition?: string
 ): TInterface {
   const name = standaloneName(schema, keyNameFromDefinition, usedNames)!
-  const jsdoc: Record<string, any> = options.jsdocTags.map(prop => [prop, schema[prop]]).reduce((acc, [key, val]) => (val !== undefined ? { ...acc, [key]: val } : acc), {});
+  const jsdoc = parseTags(schema, options.jsdocTags);
   const jsdocOrComment = isEmpty(jsdoc) ? { comment: schema.description } : { jsdoc: jsdoc };
   return {
     ...jsdocOrComment,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -317,8 +317,10 @@ function newInterface(
   keyNameFromDefinition?: string
 ): TInterface {
   const name = standaloneName(schema, keyNameFromDefinition, usedNames)!
+  const jsdoc: Record<string, any> = options.jsdocTags.map(prop => [prop, schema[prop]]).reduce((acc, [key, val]) => (val !== undefined ? { ...acc, [key]: val } : acc), {});
+  const jsdocOrComment = isEmpty(jsdoc) ? { comment: schema.description } : { jsdoc: jsdoc };
   return {
-    comment: schema.description,
+    ...jsdocOrComment,
     keyName,
     params: parseSchema(schema, options, processed, usedNames, name),
     standaloneName: name,

--- a/src/types/AST.ts
+++ b/src/types/AST.ts
@@ -1,4 +1,5 @@
 import {JSONSchema4Type} from 'json-schema'
+import {isEmpty} from 'lodash'
 
 export type AST_TYPE = AST['type']
 
@@ -23,14 +24,20 @@ export type AST =
 
 export interface AbstractAST {
   comment?: string
+  jsdoc?: Record<string, any>
   keyName?: string
   standaloneName?: string
   type: AST_TYPE
 }
 
 export type ASTWithComment = AST & {comment: string}
+export type ASTWithJSdoc = AST & { jsdoc: Record<string, any> }
 export type ASTWithName = AST & {keyName: string}
 export type ASTWithStandaloneName = AST & {standaloneName: string}
+
+export function hasJsdoc(ast: AST): ast is ASTWithJSdoc {
+  return 'jsdoc' in ast && ast.jsdoc != null && !isEmpty(ast.jsdoc)
+}
 
 export function hasComment(ast: AST): ast is ASTWithComment {
   return 'comment' in ast && ast.comment != null && ast.comment !== ''


### PR DESCRIPTION
Allow user to generate custom/unknown jsonschema properties as JSDoc tags. 
It should (help? fully?) fixes #237
Example:
```jsonc
// person.json
{
  "title": "Person",
  "type": "object",
  "properties": {
    "firstName": {
      "type": "string"
    },
    "lastName": {
      "type": "string"
    },
    "address": {
      "type": "array",
      "items": {
        "type": "string"
      },
      "default": [
        "123 Main St",
        "Anytown",
        "CA",
        "90210"
      ]
    },
    "age": {
      "description": "Age in years",
      "type": "integer",
      "minimum": 0
    },
    "hairColor": {
      "enum": ["black", "brown", "blue"],
      "type": "string"
    }
  },
  "required": ["firstName", "lastName"]
}
```
```ts
async function generate() {
  writeFileSync('person.d.ts', await compileFromFile('person.json', {jsdocTags: ["description", "minimum" , "default"]}))
}

generate()
```
generates:
```ts
/* tslint:disable */
/**
 * This file was automatically generated by json-schema-to-typescript.
 * DO NOT MODIFY IT BY HAND. Instead, modify the source JSONSchema file,
 * and run json-schema-to-typescript to regenerate this file.
 */

export interface Person {
  firstName: string;
  lastName: string;
  /**
   * @default ["123 Main St","Anytown","CA","90210"]
   */
  address?: string[];
  /**
   * @description "Age in years"
   * @minimum 0
   */
  age?: number;
  hairColor?: "black" | "brown" | "blue";
  [k: string]: unknown;
}
```