### PR TITLE
inline object POC

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -5,5 +5,9 @@ export function format(code: string, options: Options): string {
   if (!options.format) {
     return code
   }
-  return prettify(code, {parser: 'typescript', ...options.style})
+  const wrapStart = 'type A = '
+  let formatted = prettify(wrapStart+code, {parser: 'typescript', ...options.style})
+  formatted = formatted.slice(wrapStart.length);
+  formatted = formatted.replace(/;\s*$/, '')
+  return formatted
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -17,16 +17,18 @@ import {
 import {log, toSafeString} from './utils'
 
 export function generate(ast: AST, options = DEFAULT_OPTIONS): string {
-  return (
-    [
-      options.bannerComment,
-      declareNamedTypes(ast, options, ast.standaloneName!),
-      declareNamedInterfaces(ast, options, ast.standaloneName!),
-      declareEnums(ast, options)
-    ]
-      .filter(Boolean)
-      .join('\n\n') + '\n'
-  ) // trailing newline
+  return generateTypeUnmemoized(ast, options).toString()
+  // console.log(a)
+  // return (
+  //   [
+  //     options.bannerComment,
+  //     declareNamedTypes(ast, options, ast.standaloneName!),
+  //     declareNamedInterfaces(ast, options, ast.standaloneName!),
+  //     declareEnums(ast, options)
+  //   ]
+  //     .filter(Boolean)
+  //     .join('\n\n') + '\n'
+  // ) // trailing newline
 }
 
 function declareEnums(ast: AST, options: Options, processed = new Set<AST>()): string {

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -300,6 +300,7 @@ function standaloneName(
   keyNameFromDefinition: string | undefined,
   usedNames: UsedNames
 ): string | undefined {
+  return undefined
   const name = schema.title || schema.$id || keyNameFromDefinition
   if (name) {
     return generateName(name, usedNames)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "noFallthroughCasesInSwitch": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "noUnusedParameters": true,
     "outDir": "dist",
     "preserveConstEnums": true,


### PR DESCRIPTION
Hey. This is POC of generating inline nested types.
If it's something that could be merged, I'll finish PR: put it under flag `generateInlineTypes: true` and add tests. 
Yeah, I know it's more limiting, but lib consumer sometimes needs to have inline type. 
Also I'll throw an error if smth could be not generated (e.g. recursive types). 