### PR TITLE
perf: remove blank character at the beginning of string result

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ export function compileFromFile(filename: string, options: Partial<Options> = DE
     }
   )
   const schema = Try<JSONSchema4>(
-    () => JSON.parse(contents.toString()),
+    () => JSON.parse(contents.toString().trim()),
     () => {
       throw new TypeError(`Error parsing JSON in file "${filename}"`)
     }


### PR DESCRIPTION
When I try to read a file encoding in utf-8 BOM,  it return a string with a "blank" as first character,  I looked into the code and found this error:

```
SyntaxError: Unexpected token ﻿ in JSON at position 0
    at JSON.parse (<anonymous>)
    at compileFromFile  (....)
```
Thus, I believe we should add a trim to remove the blank characters

Related issue: https://github.com/nodejs/node/issues/20649