### PR TITLE
Fixed eslint extension setting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["prettier/@typescript-eslint", "plugin:prettier/recommended"],
+  "extends": ["prettier", "plugin:prettier/recommended"],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaVersion": 2020,


### PR DESCRIPTION
Cloning the repo and attempting to run the 'build' script crashes with the error below. The issue, as explained in [ESlint Config Update](https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md) is that we are now to use 'prettier' instead of the older, 'prettier/@typescript-eslint'.


Error details:
ESLint: 8.25.0

Error: Cannot read config file: /home/tom/source/opensource/json-schema-to-typescript/node_modules/eslint-config-prettier/@typescript-eslint.js
Error: "prettier/@typescript-eslint" has been merged into "prettier" in eslint-config-prettier 8.0.0. See: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21
Referenced from: /home/tom/source/opensource/json-schema-to-typescript/.eslintrc.json
    at Object.<anonymous> (/home/tom/source/opensource/json-schema-to-typescript/node_modules/eslint-config-prettier/@typescript-eslint.js:1:7)
    at Module._compile (node:internal/modules/cjs/loader:1120:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1174:10)
    at Module.load (node:internal/modules/cjs/loader:998:32)
    at Module._load (node:internal/modules/cjs/loader:839:12)
    at Module.require (node:internal/modules/cjs/loader:1022:19)
    at module.exports [as default] (/home/tom/source/opensource/json-schema-to-typescript/node_modules/import-fresh/index.js:32:59)
    at loadJSConfigFile (/home/tom/source/opensource/json-schema-to-typescript/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2562:47)
    at loadConfigFile (/home/tom/source/opensource/json-schema-to-typescript/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2646:20)
    at ConfigArrayFactory._loadConfigData (/home/tom/source/opensource/json-schema-to-typescript/node_modules/@eslint/eslintrc/dist/eslintrc.cjs:2963:42)
