### PR TITLE
Make index properties optional

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -364,10 +364,10 @@ function parseSchema(
     // additionalProperties is not set, and there is only a single
     // value definition, we can validate against that.
     singlePatternProperty = !schema.additionalProperties && Object.keys(schema.patternProperties).length === 1
-
     asts = asts.concat(
       map(schema.patternProperties, (value, key: string) => {
         const ast = parse(value, options, key, processed, usedNames)
+        //TODO: Modify ast here to add union with undefined, or add undefined to union
         const comment = `This interface was referenced by \`${parentSchemaName}\`'s JSON-Schema definition
 via the \`patternProperty\` "${key}".`
         ast.comment = ast.comment ? `${ast.comment}\n\n${comment}` : comment

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -364,6 +364,7 @@ function parseSchema(
     // additionalProperties is not set, and there is only a single
     // value definition, we can validate against that.
     singlePatternProperty = !schema.additionalProperties && Object.keys(schema.patternProperties).length === 1
+
     asts = asts.concat(
       map(schema.patternProperties, (value, key: string) => {
         const ast = parse(value, options, key, processed, usedNames)

--- a/src/types/AST.ts
+++ b/src/types/AST.ts
@@ -13,6 +13,7 @@ export type AST =
   | TLiteral
   | TNumber
   | TNull
+  | TUndefined
   | TObject
   | TReference
   | TString
@@ -103,6 +104,10 @@ export interface TNumber extends AbstractAST {
 
 export interface TNull extends AbstractAST {
   type: 'NULL'
+}
+
+export interface TUndefined extends AbstractAST {
+  type: 'UNDEFINED'
 }
 
 export interface TObject extends AbstractAST {

--- a/src/typesOfSchema.ts
+++ b/src/typesOfSchema.ts
@@ -119,6 +119,9 @@ const matchers: Record<SchemaType, (schema: JSONSchema) => boolean> = {
     }
     return 'items' in schema
   },
+  UNDEFINED(schema) {
+    return schema.type === 'undefined'
+  },
   UNION(schema) {
     return Array.isArray(schema.type)
   },


### PR DESCRIPTION
In https://github.com/trufflesuite/truffle/issues/5746 there is an example of a schema where several properties are specified in addition to a patternProperty.  In converting this to TypeScript types, this library marks the properties as optional (i.e. allowing undefined) while the index property is not marked as allowing `undefined`. This produces TS compilation errors because the type of a specified property (which allows for `undefined`) is not assignable to the type of the index property (which does not allow for `undefined`).  
This seems like it would likely affect more than just that one example, so fixing it here seems like the best place. 
This PR gets part of the way there but doesn't fully fix the issue, leaving a TODO where someone who knows this codebase better than I do can pick up much more effectively.  
I would welcome other contributions and/or maintainer edits that get this farther along. 