### PR TITLE
Generate .d.ts files parallel to .json

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -158,8 +158,9 @@ ${pkg.name} ${pkg.version}
 Usage: json2ts [--input, -i] [IN_FILE] [--output, -o] [OUT_FILE] [--multi, -m] [OPTIONS]
 
 With no IN_FILE, or when IN_FILE is -, read standard input.
-With no OUT_FILE and when IN_FILE is specified, write to standard output.
-With no OUT_FILE and when IN_FILE and is specified and --multi is set, create .d.ts file in the same directory of .json file.
+With no OUT_FILE and when IN_FILE is a dir, create .d.ts file in the same directory..
+With no OUT_FILE and when IN_FILE is a glob, write to standard output.
+With no OUT_FILE and when IN_FILE is a glob and --multi is set, create .d.ts file in the same directory as .json file.
 With no OUT_FILE nor IN_FILE, write to standard output.
 
 You can use any of the following options by adding them at the end.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -155,10 +155,11 @@ function printHelp() {
   process.stdout.write(
     `
 ${pkg.name} ${pkg.version}
-Usage: json2ts [--input, -i] [IN_FILE] [--output, -o] [OUT_FILE] [OPTIONS]
+Usage: json2ts [--input, -i] [IN_FILE] [--output, -o] [OUT_FILE] [--multi, -m] [OPTIONS]
 
 With no IN_FILE, or when IN_FILE is -, read standard input.
-With no OUT_FILE and when IN_FILE is specified, create .d.ts file in the same directory.
+With no OUT_FILE and when IN_FILE is specified, write to standard output.
+With no OUT_FILE and when IN_FILE and is specified and --multi is set, create .d.ts file in the same directory of .json file.
 With no OUT_FILE nor IN_FILE, write to standard output.
 
 You can use any of the following options by adding them at the end.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -77,7 +77,8 @@ async function processGlob(argIn: string, argOut: string | undefined, argv: Part
 
   // careful to do this serially
   results.forEach(([file, result]) => {
-    const outputPath = argOut && `${argOut}/${basename(file, '.json')}.d.ts`
+    const outputDir = argOut || dirname(file)
+    const outputPath = `${outputDir}/${basename(file, '.json')}.d.ts`
     outputResult(result, outputPath)
   })
 }


### PR DESCRIPTION
This is a implementeation of the feature flag suggested by @Blfrg in https://github.com/bcherny/json-schema-to-typescript/issues/360.

It allows to use glob input files and generates `.d.ts` parallel to the original `.json` file.

As it was noted by @bcherny the help text does not reflect the actual behaviour in case of glob, so at least I would suggest to adjust the help text there.