### PR TITLE
add `commentStyle` option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dist/
 dist_tests/
 package-lock.json
 yarn-error.log
+bun.lockb

--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ See [server demo](example) and [browser demo](https://github.com/bcherny/json-sc
 | unknownAny | boolean | `true` | Use `unknown` instead of `any` where possible |
 | unreachableDefinitions | boolean | `false` | Generates code for `$defs` that aren't referenced by the schema. |
 | $refOptions | object | `{}` | [$RefParser](https://github.com/BigstickCarpet/json-schema-ref-parser) Options, used when resolving `$ref`s |
+| commentStyle | `'block' \| 'line'` | `'block'` | Comment style for describing types. When set to `line`, multiline comments are collapsed to a single line. |
+
 ## CLI
 
 A CLI utility is provided with this package.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -26,9 +26,9 @@ main(
       'strictIndexSignatures',
       'unknownAny',
       'unreachableDefinitions',
-    ],
+    ] satisfies (keyof Options)[],
     default: DEFAULT_OPTIONS,
-    string: ['bannerComment', 'cwd'],
+    string: ['bannerComment', 'cwd', 'commentStyle'] satisfies (keyof Options)[],
   }),
 )
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,13 @@ export interface Options {
    * Generate unknown type instead of any
    */
   unknownAny: boolean
+  /**
+   * Comment style for describing types.
+   * When set to line, multiline comments are collapsed to a single line.
+   *
+   * @default 'block'
+   */
+  commentStyle: 'block' | 'line'
 }
 
 export const DEFAULT_OPTIONS: Options = {
@@ -105,6 +112,7 @@ export const DEFAULT_OPTIONS: Options = {
   },
   unreachableDefinitions: false,
   unknownAny: true,
+  commentStyle: 'block',
 }
 
 export function compileFromFile(filename: string, options: Partial<Options> = DEFAULT_OPTIONS): Promise<string> {


### PR DESCRIPTION
Adds a `commentStyle` option. Allows the user to choose from block or line comments.

I am using this package with LLMs. Since machines don't really care about the nicely formatted TSdoc comments, I wanted to switch to line comments `// this is a comment`. This way I can save on tokens and keep the prompt shorter to reduce hallucinations.

This is a non-breaking change as it keeps the default as `block`.