### PR TITLE
enhancement bcherny#543 - Prefix items support

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-
 import minimist = require('minimist')
 import getStdin from 'get-stdin'
 import {readFile, writeFile, existsSync, lstatSync, readdirSync} from 'mz/fs'
@@ -26,6 +25,7 @@ main(
       'strictIndexSignatures',
       'unknownAny',
       'unreachableDefinitions',
+      'usePrefixItems',
     ],
     default: DEFAULT_OPTIONS,
     string: ['bannerComment', 'cwd'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,11 @@ export interface Options {
    */
   maxItems: number
   /**
+   * Use `prefixItems` and `items` instead of `items` and `additionalItems` for tuple validation. This change was introduced in the 2020-12 Release Notes of the
+   * JSON Schema specification. [Read more about this](https://json-schema.org/draft/2020-12/release-notes#2020-12-release-notes)
+   */
+  usePrefixItems: boolean
+  /**
    * Append all index signatures with `| undefined` so that they are strictly typed.
    *
    * This is required to be compatible with `strictNullChecks`.
@@ -93,6 +98,7 @@ export const DEFAULT_OPTIONS: Options = {
   format: true,
   ignoreMinAndMaxItems: false,
   maxItems: 20,
+  usePrefixItems: false,
   strictIndexSignatures: false,
   style: {
     bracketSpacing: false,

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import {JSONSchemaTypeName, LinkedJSONSchema, NormalizedJSONSchema, Parent} from './types/JSONSchema'
 import {appendToDescription, escapeBlockComment, isSchemaLike, justName, toSafeString, traverse} from './utils'
 import {Options} from './'
@@ -20,7 +21,9 @@ function isObjectType(schema: LinkedJSONSchema) {
   return schema.properties !== undefined || hasType(schema, 'object') || hasType(schema, 'any')
 }
 function isArrayType(schema: LinkedJSONSchema) {
-  return schema.items !== undefined || hasType(schema, 'array') || hasType(schema, 'any')
+  return (
+    schema.items !== undefined || schema.prefixItems !== undefined || hasType(schema, 'array') || hasType(schema, 'any')
+  )
 }
 
 rules.set('Remove `type=["null"]` if `enum=[null]`', schema => {
@@ -103,6 +106,16 @@ rules.set('Add an $id to anything that needs it', (schema, fileName, _options, _
 
 rules.set('Escape closing JSDoc comment', schema => {
   escapeBlockComment(schema)
+})
+
+rules.set('Rename `prefixItems` to `items` and `items` to `additionallItems`', (schema, _, options) => {
+  if (isArrayType(schema) && options.usePrefixItems) {
+    // @ts-expect-error this is a simple renaming procedure, there is in no need to change the `schema.items` type to allow for boolean values
+    schema.additionalItems = schema.items
+    schema.items = schema.prefixItems
+    delete schema.prefixItems
+  }
+  return
 })
 
 rules.set('Add JSDoc comments for minItems and maxItems', schema => {

--- a/test/normalizer/renamePrefixItemsToItems.json
+++ b/test/normalizer/renamePrefixItemsToItems.json
@@ -1,0 +1,31 @@
+{
+  "name": "Rename prefixItems to items and items to additionalItems",
+  "in": {
+    "additionalProperties": false,
+    "$id": "RenamePrefixItems",
+    "properties":{
+      "a": {
+        "description": "Test prefixItems",
+        "prefixItems": [true, false],
+        "items":false
+      }
+    },
+    "required": []
+    },
+  "out": {
+    "additionalProperties": false,
+    "$id": "RenamePrefixItems",
+    "properties": {
+      "a": {
+        "description": "Test prefixItems",
+        "items": [true, false],
+        "additionalItems": false,
+        "minItems": 0
+      }
+    },
+    "required": []
+  },
+  "options": {
+    "usePrefixItems": true
+  }
+}


### PR DESCRIPTION
### Added optional `--usePrefixItems` flag that defaults to false. 

When passed JSON schemas containing `prefixItems` and `items` keys are normalized as `items` and `additionalItems`, as per JSON Schema [Draft 2020-12](https://json-schema.org/draft/2020-12/release-notes). 

The draft also contains changes to the `$recursiveRef` and `$recursiveAnchor` keywords, which this PR does not deal with. 

✔Tests added

















