### PR TITLE
fix: force resolution of es5-ext

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "watch": "tsc -w",
     "watch:test": "ava -w"
   },
+  "resolutions": {
+    "es5-ext": "0.10.53"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bcherny/json-schema-to-typescript.git"


### PR DESCRIPTION
Force resolution of es5-ext is being flagged as malware.
Because of postinstall script of a dependency printing out a message to users in Russian time zones. https://github.com/medikoo/es5-ext/issues/116
Relevant to https://github.com/medikoo/es5-ext/issues/186 ("package being detected as a virus")