### PR TITLE
Fix: tsconfig.json for building on darwin

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
     "skipLibCheck": true,
     "sourceMap": true,
     "strict": true,
-    "target": "es6"
+    "target": "es6",
+    "forceConsistentCasingInFileNames": false
   },
   "exclude": [
     "example",


### PR DESCRIPTION
This adds: `forceConsistentCasingInFileNames: false`.

File system casing on darwin machines behaves differently from windows or linux which causes the follwing problem.

```
> json-schema-to-typescript@15.0.2 build
> npm run lint && npm run clean && npm run build:browser && npm run build:server


> json-schema-to-typescript@15.0.2 lint
> eslint src/*.ts test/*.ts


> json-schema-to-typescript@15.0.2 clean
> shx rm -rf dist && mkdir dist


> json-schema-to-typescript@15.0.2 build:browser
> browserify src/index.ts -s jstt -p tsify > dist/bundle.js

TypeScript error: /private/tmp/nix-build-json2ts.drv-0/source/src/applyschematyping.ts(1,37): Error TS1261: Already included file name '/private/tmp/nix-build-json2ts.drv-0/source/src/types/JSONSchema.ts' differs from file name '/private/tmp/nix-build-json2ts.drv-0/source/src/types/jsonschema.ts' only in casing.
  The file is in the program because:
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/applyschematyping.ts'
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/applyschematyping.ts'
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/typesOfSchema.ts'
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/utils.ts'
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/normalizer.ts'
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/resolver.ts'
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/parser.ts'
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/parser.ts'
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/validator.ts'
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/linker.ts'
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/index.ts'
    Imported via './types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/src/index.ts'
    Root file specified for compilation
    Imported via '../src/types/JSONSchema' from file '/private/tmp/nix-build-json2ts.drv-0/source/test/testLinker.ts'

ERROR: `npm build` failed
```