### PR TITLE
Fix step reference in architecture docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,7 +22,7 @@ Parses JSONSchema to an intermediate representation for easy code generation.
 
 #### 6. Optimizer
 
-Optimizes the IR to produce concise and readable TypeScript in step (6).
+Optimizes the IR to produce concise and readable TypeScript in step (7).
 
 #### 7. Generator
 


### PR DESCRIPTION
## Summary
- correct the optimizer description to reference step (7)

## Testing
- `npm test` *(fails: shx not found)*