### PR TITLE
feat: custom schema extension

### DIFF
--- a/src/applySchemaTyping.ts
+++ b/src/applySchemaTyping.ts
@@ -1,9 +1,10 @@
 import type {LinkedJSONSchema} from './types/JSONSchema'
 import {Intersection, Parent, Types} from './types/JSONSchema'
 import {typesOfSchema} from './typesOfSchema'
+import {Options} from './'
 
-export function applySchemaTyping(schema: LinkedJSONSchema) {
-  const types = typesOfSchema(schema)
+export function applySchemaTyping(schema: LinkedJSONSchema, options?: Options) {
+  const types = typesOfSchema(schema, options)
 
   Object.defineProperty(schema, Types, {
     enumerable: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,6 +85,13 @@ export interface Options {
    * Generate unknown type instead of any
    */
   unknownAny: boolean
+  /**
+   * Custom parser extensions for unsupported schema types
+   */
+  parserExtensions?: Record<
+    string,
+    (schema: Record<string, unknown>, compileSchema: (schema: Record<string, unknown>) => string) => string
+  >
 }
 
 export const DEFAULT_OPTIONS: Options = {

--- a/src/normalizer.ts
+++ b/src/normalizer.ts
@@ -242,9 +242,9 @@ rules.set('Add tsEnumNames to enum types', (schema, _, options) => {
 // the intersection schema needs to participate in the schema cache during
 // the parsing step, so it cannot be re-calculated every time the schema
 // is encountered.
-rules.set('Pre-calculate schema types and intersections', schema => {
+rules.set('Pre-calculate schema types and intersections', (schema, _fileName, options) => {
   if (schema !== null && typeof schema === 'object') {
-    applySchemaTyping(schema)
+    applySchemaTyping(schema, options)
   }
 })
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -15,6 +15,7 @@ import type {
 } from './types/JSONSchema'
 import {Intersection, Types, getRootSchema, isBoolean, isPrimitive} from './types/JSONSchema'
 import {generateName, log, maybeStripDefault} from './utils'
+import {generateType} from './generator'
 
 export type Processed = Map<NormalizedJSONSchema, Map<SchemaType, AST>>
 
@@ -157,15 +158,42 @@ function parseNonLiteral(
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
         type: 'BOOLEAN',
       }
-    case 'CUSTOM_TYPE':
+    case 'CUSTOM_TYPE': {
+      let customType: string
+
+      if (schema.tsType) {
+        customType = schema.tsType
+      } else if (options.parserExtensions && schema.type && typeof schema.type === 'string') {
+        const extension = options.parserExtensions[schema.type]
+        if (extension) {
+          // Create a compilation callback for nested schemas
+          const compileSchema = (nestedSchema: any): string => {
+            // Clone the schema to avoid modifying the original
+            const clonedSchema = {...nestedSchema}
+            if (!clonedSchema[Types]) {
+              applySchemaTyping(clonedSchema, options)
+            }
+            const ast = parse(clonedSchema, options, undefined, processed, usedNames)
+            return generateType(ast, options)
+          }
+
+          customType = extension(schema, compileSchema)
+        } else {
+          customType = 'any'
+        }
+      } else {
+        customType = 'any'
+      }
+
       return {
         comment: schema.description,
         deprecated: schema.deprecated,
         keyName,
-        params: schema.tsType!,
+        params: customType,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
         type: 'CUSTOM_TYPE',
       }
+    }
     case 'NAMED_ENUM':
       return {
         comment: schema.description,
@@ -271,7 +299,7 @@ function parseNonLiteral(
         params: (schema.type as JSONSchema4TypeName[]).map(type => {
           const member: LinkedJSONSchema = {...omit(schema, '$id', 'description', 'title'), type}
           maybeStripDefault(member)
-          applySchemaTyping(member)
+          applySchemaTyping(member, options)
           return parse(member, options, undefined, processed, usedNames)
         }),
         type: 'UNION',

--- a/src/typesOfSchema.ts
+++ b/src/typesOfSchema.ts
@@ -1,5 +1,6 @@
 import {isPlainObject} from 'lodash'
 import {isCompound, JSONSchema, SchemaType} from './types/JSONSchema'
+import {Options} from './'
 
 /**
  * Duck types a JSONSchema schema or property to determine which kind of AST node to parse it into.
@@ -9,10 +10,16 @@ import {isCompound, JSONSchema, SchemaType} from './types/JSONSchema'
  * types). The spec leaves it up to implementations to decide what to do with this
  * loosely-defined behavior.
  */
-export function typesOfSchema(schema: JSONSchema): Set<SchemaType> {
+export function typesOfSchema(schema: JSONSchema, options?: Options): Set<SchemaType> {
   // tsType is an escape hatch that supercedes all other directives
   if (schema.tsType) {
     return new Set(['CUSTOM_TYPE'])
+  }
+
+  if (options?.parserExtensions && schema.type && typeof schema.type === 'string') {
+    if (schema.type in options.parserExtensions) {
+      return new Set(['CUSTOM_TYPE'])
+    }
   }
 
   // Collect matched types


### PR DESCRIPTION
## Overview

This PR adds support for parsing custom schema extension with `parserExtensions` option. This is not based on any concrete issue but just on my personal problem that I'm trying to solve. For context:
- Somewhat related issue that I found https://github.com/bcherny/json-schema-to-typescript/issues/2
- "Custom JSON-schema extensions" are mentioned in [the README's features](https://github.com/bcherny/json-schema-to-typescript/blob/43ba08b117adcce82ae2f13e9abd73314680a695/README.md?plain=1#L172), which led me to assume this PR might be welcome

## Problem

We use `@sinclair/typebox` + `json-schema-to-typescript` to share types between services and we have some non-standard schemas. Specifically, we commonly use `typebox`'es "Javascript constructs" like [`Type.Function`](https://sinclairzx81.github.io/typebox/#/docs/type/function).

Let's say I have this

```ts
import { Type } from '@sinclair/typebox';

const Test = Type.Function([Type.String()], Type.Number())

/*
which is just this JSON ⬇️
{
  type: 'Function',
  parameters: [
    {
      type: 'string',
    },
  ],
  returns: {
    type: 'number',
  },
}
*/
```

In this `compile` will just default to `CUSTOM_TYPE` which makes sense.

```ts
export interface Test {
  [k: string]: unknown;
}
```


Currently we hack around this issue with `tsType` like so

```ts
const Test = {
	...Type.Function([Type.String()], Type.Number()),
	tsType: '(someArg: string) => number',
}
```

which gets us the correct type.

```ts
export type Test = ((someArg: string) => number) => number;
```


While this, works you can already start to feel that we're doing some duplicated work which might be very error prone (`Type.String` and `Type.Number` are already handled by `json-schema-to-typescript`). Add one more level to the schema and `tsType` just becomes not worth it for us

```ts
const Test = Type.Function([
	Type.Object({
		id: Type.String(),
		name: Type.String(),
	})
], Type.Number());

/*
which is just this JSON ⬇️
{
  type: 'Function',
  parameters: [
    {
      type: 'object',
      properties: {
        id: {type: 'number'},
        name: {type: 'string'},
      },
      required: ['id'],
    },
  ],
  returns: {
    type: 'number',
  },
}
*/
```

## Solution

Added `parserExtensions` option that allows defining a custom compile callback for unsupported `type`. When `type` matches, it runs the callback. Callback provides the current `schema` that's being parsed and `compileSchema` callback to basically pass the parsing back to the library.

### Simple example

```ts
const Test = { type: 'myCustomString' };

compile(Test as any, 'test', {
  bannerComment: '',
  format: true,
  parserExtensions: {
    myCustomString: () => 'string',
  },
})
```

results in

```ts
export type Test = string;
```

### Complicated example (with the mentioned `Type.Function`)

```ts
const Test = {
  type: 'Function',
  parameters: [
    {
      type: 'object',
      properties: {
        id: {type: 'number'},
        name: {type: 'string'},
      },
      required: ['id'],
    },
  ],
  returns: {
    type: 'number',
  },
}

compile(Test as any, 'test', {
  bannerComment: '',
  format: true,
  parserExtensions: {
    Function: (schema: any, compileSchema) => {
      const paramTypes = schema.parameters
        ? schema.parameters.map((param: any, index: number) => {
            const paramType = compileSchema(param)
            return `param${index}: ${paramType}`
          })
        : []

      const returnType = schema.returns ? compileSchema(schema.returns) : 'void'

      return `(${paramTypes.join(', ')}) => ${returnType}`
    },
  },
})
```

results in

```ts
export type Test = (param0: {id: number; name?: string; [k: string]: unknown}) => number;
```

## Side Note

I'm well aware that I need to add tests. Willing to do that add and fix any concerns. Want to validate first if the idea is even welcome though 🙏, @bcherny.