### PR TITLE
compileSync

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ json2ts -i foo.json -o foo.d.ts --style.singleQuote --no-style.semi
 To invoke json-schema-to-typescript from your TypeScript or JavaScript program, import it and call `compile` or `compileFromFile`.
 
 ```js
-import { compile, compileFromFile } from 'json-schema-to-typescript'
+import { compile, compileFromFile, compileSync } from 'json-schema-to-typescript'
 
 // compile from file
 compileFromFile('foo.json')
@@ -122,6 +122,9 @@ let mySchema = {
 }
 compile(mySchema, 'MySchema')
   .then(ts => ...)
+
+// or, compile a JS object synchronously, if there are not remote refs
+const ts = compileSync(mySchema, 'MySchema')
 ```
 
 See [server demo](example) and [browser demo](https://github.com/bcherny/json-schema-to-typescript-browser) for full examples.

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,43 @@ function parseAsJSONSchema(filename: string): JSONSchema4 {
   return parseFileAsJSONSchema(filename, contents.toString())
 }
 
-export async function compile(schema: JSONSchema4, name: string, options: Partial<Options> = {}): Promise<string> {
+export async function compile(
+  schema: JSONSchema4,
+  name: string,
+  options: Partial<Options> & {
+    dereferenced?: Awaited<ReturnType<typeof dereference>>
+  } = {},
+): Promise<string> {
+  validateOptions(options)
+
+  const _options = merge({}, DEFAULT_OPTIONS, options)
+
+  const start = Date.now()
+  function time() {
+    return `(${Date.now() - start}ms)`
+  }
+
+  // normalize options
+  if (!endsWith(_options.cwd, '/')) {
+    _options.cwd += '/'
+  }
+
+  // Initial clone to avoid mutating the input
+  const _schema = cloneDeep(schema)
+  const dereferenced = await dereference(_schema, _options)
+  const generated = compileSync(schema, name, {...options, dereferenced})
+
+  const formatted = await format(generated, _options)
+  log('white', 'formatter', time(), '✅ Result:', formatted)
+
+  return formatted
+}
+
+export function compileSync(
+  schema: JSONSchema4,
+  name: string,
+  options: Partial<Options> & {dereferenced?: Awaited<ReturnType<typeof dereference>>} = {},
+): string {
   validateOptions(options)
 
   const _options = merge({}, DEFAULT_OPTIONS, options)
@@ -150,7 +186,10 @@ export async function compile(schema: JSONSchema4, name: string, options: Partia
   // Initial clone to avoid mutating the input
   const _schema = cloneDeep(schema)
 
-  const {dereferencedPaths, dereferencedSchema} = await dereference(_schema, _options)
+  const {dereferencedPaths, dereferencedSchema} = options.dereferenced || {
+    dereferencedPaths: new WeakMap(),
+    dereferencedSchema: _schema,
+  }
   if (process.env.VERBOSE) {
     if (isDeepStrictEqual(_schema, dereferencedSchema)) {
       log('green', 'dereferencer', time(), '✅ No change')
@@ -185,10 +224,7 @@ export async function compile(schema: JSONSchema4, name: string, options: Partia
   const generated = generate(optimized, _options)
   log('magenta', 'generator', time(), '✅ Result:', generated)
 
-  const formatted = await format(generated, _options)
-  log('white', 'formatter', time(), '✅ Result:', formatted)
-
-  return formatted
+  return generated
 }
 
 export class ValidationError extends Error {}


### PR DESCRIPTION
Hi!

At iterate, we have a usecase where we want to turn some inline json-schema objects into typescript, inside a non-async function. There are no remote refs, and we don't need prettier, so I poked around to see if it would be possible. Turns out to be pretty easy, and you can even support remote refs by just passing them in. I added a `compileSync` overload for it.

For anyone interested, I published to npm under [@mmkal/json-schema-to-typescript](https://npmjs.com/package/@mmkal/json-schema-to-typescript) but it'd be great if this could be merged into this lib.