### PR TITLE
[CI] Test under bun

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,33 @@ jobs:
       env:
         CI: true
 
+  # Bun is not a supported target, but plenty of users run json2ts under it, so
+  # this job catches breakage early. bun install migrates package-lock.json, so
+  # the versions it resolves match the node jobs without a second lockfile.
+  bun:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: Use Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: latest
+    - name: Install dependencies
+      run: bun install
+    - name: Run tests
+      run: bun run test
+      env:
+        CI: true
+    - name: Run the built CLI under bun
+      run: bun dist/src/cli.js test/resources/Schema.yaml
+
   # Aggregate check. Branch protection requires this one job instead of each
   # matrix job by name, so the matrix can change without editing the required
   # status checks.
   ci-ok:
     if: always()
-    needs: build
+    needs: [build, bun]
     runs-on: ubuntu-latest
     steps:
     - name: Fail if any matrix job did not succeed

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 !.yarn/versions
 npm-debug.log
 node_modules
+# bun install migrates package-lock.json, so this is generated, never committed
+bun.lock
 *.js
 *.map
 dist/


### PR DESCRIPTION
Adds a `bun` job to CI alongside the existing node matrix.

## What it runs

- `bun install`
- `bun run test` — the full ava suite (162 tests)
- `bun dist/src/cli.js test/resources/Schema.yaml` — the built CLI, to cover the artifact users actually run

## Notes

- **No second lockfile.** `bun install` migrates `package-lock.json` (`migrated lockfile from package-lock.json`), so the bun job resolves the same versions as the node jobs — verified locally: typescript 6.0.3, ava 8.0.1, eslint 10.8.0, js-yaml 5.2.3. The generated `bun.lock` is gitignored so it can't drift from npm's.
- **Gating comes free.** The job is added to `ci-ok`'s `needs`, so it blocks merges without touching branch protection — which is the point of the aggregate check added in #686.
- **Bun is not a declared support target.** `engines` still says node `>=16`; this job exists to catch bun breakage early, since users do run `json2ts` under it.

## Verified locally against bun 1.3.11, from a clean `node_modules`

`bun install`, `bun x tsc -d`, `bun run test` (162 passed), `bun run lint`, `bun run build` (including the browserify/tsify bundle), the CLI, and both `require()` and `import()` of the built package.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHQj1MmJwBxtu8RsAPewwt)_