### PR TITLE
Add smoke tests to verify package works on Node 16+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,12 +29,41 @@ jobs:
       env:
         CI: true
 
+  # package.json claims node >=16, but ava 8 needs >=22, so the suite can't run
+  # on the older versions. Build on a current node, then exercise the built
+  # package on every version the package claims to support.
+  engines:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [16.x, 18.x, 20.x]
+
+    steps:
+    - uses: actions/checkout@v5
+    - name: Use Node.js 24.x to build
+      uses: actions/setup-node@v5
+      with:
+        node-version: 24.x
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+    - name: Build
+      run: npm run build:server
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v5
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Smoke-test the built package
+      run: node test/smoke.cjs
+
   # Aggregate check. Branch protection requires this one job instead of each
   # matrix job by name, so the matrix can change without editing the required
   # status checks.
   ci-ok:
     if: always()
-    needs: build
+    needs: [build, engines]
     runs-on: ubuntu-latest
     steps:
     - name: Fail if any matrix job did not succeed

--- a/test/smoke.cjs
+++ b/test/smoke.cjs
@@ -1,0 +1,47 @@
+// package.json declares `engines.node: >=16`, but the dev toolchain (ava 8)
+// requires node >=22, so the test suite can't run on the oldest supported
+// versions. This script exercises the *built* package instead — the artifact
+// that actually ships — and CI runs it on every node version we claim to
+// support, so the declared floor stays honest.
+//
+// Usage: node test/smoke.cjs
+
+const assert = require('assert')
+const {execFileSync} = require('child_process')
+const {join} = require('path')
+
+const {compile, compileFromFile} = require('../dist/src/index.js')
+
+const CLI = join(__dirname, '..', 'dist', 'src', 'cli.js')
+const YAML_SCHEMA = join(__dirname, 'resources', 'Schema.yaml')
+
+async function main() {
+  const fromSchema = await compile(
+    {
+      title: 'Example',
+      type: 'object',
+      properties: {name: {type: 'string'}, age: {type: 'integer'}},
+      required: ['name'],
+    },
+    'Example',
+  )
+  assert.match(fromSchema, /export interface Example/)
+  assert.match(fromSchema, /name: string/)
+  assert.match(fromSchema, /age\?: number/)
+
+  // Exercises js-yaml, which is where an old-node incompatibility would most
+  // likely show up first.
+  const fromYaml = await compileFromFile(YAML_SCHEMA)
+  assert.match(fromYaml, /export interface ExampleSchema/)
+  assert.match(fromYaml, /firstName: string/)
+
+  const fromCli = execFileSync(process.execPath, [CLI, YAML_SCHEMA], {encoding: 'utf-8'})
+  assert.match(fromCli, /export interface ExampleSchema/)
+
+  console.log(`smoke test passed on node ${process.version}`)
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary
This PR adds a smoke test suite that verifies the built package works correctly on all Node.js versions declared as supported (16.x, 18.x, 20.x), since the main test suite requires Node 22+.

## Key Changes
- **Added `test/smoke.cjs`**: A CommonJS smoke test script that exercises the built package by:
  - Testing the `compile()` API with an inline schema
  - Testing the `compileFromFile()` API with a YAML schema file
  - Testing the CLI with a YAML schema file
  - Verifying output contains expected TypeScript interface definitions
  
- **Updated `.github/workflows/ci.yml`**: Added a new `engines` job that:
  - Builds the package once on Node 24.x
  - Runs the smoke test on each supported Node version (16.x, 18.x, 20.x)
  - Ensures the declared engine floor (`node >=16`) stays honest
  - Updated the `ci-ok` aggregate check to require both `build` and `engines` jobs

## Implementation Details
The smoke test uses only Node.js built-in modules (`assert`, `child_process`, `path`) to avoid introducing new dependencies. It specifically exercises `js-yaml` (a transitive dependency) since that's where old-Node incompatibilities would most likely surface first.

https://claude.ai/code/session_01VHQj1MmJwBxtu8RsAPewwt