### PR TITLE
Fix YAML parsing regression from js-yaml@5 migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,4 +38,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Fail if any matrix job did not succeed
-      run: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+      # Checking for success (rather than for failure/cancellation) also catches
+      # `skipped`, which would otherwise satisfy branch protection with no tests run.
+      run: '[ "${{ needs.build.result }}" = "success" ]'

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,7 +2,7 @@ import {deburr, isPlainObject, trim, upperFirst} from 'lodash'
 import {basename, dirname, extname, normalize, sep, posix} from 'path'
 import {Intersection, JSONSchema, LinkedJSONSchema, NormalizedJSONSchema, Parent} from './types/JSONSchema'
 import {JSONSchema4} from 'json-schema'
-import {load as loadYaml, YAML11_SCHEMA} from 'js-yaml'
+import {binaryTag, CORE_SCHEMA, load as loadYaml, mergeTag, omapTag, pairsTag, setTag, timestampTag} from 'js-yaml'
 import type {Format} from 'cli-color'
 
 // TODO: pull out into a separate package
@@ -391,13 +391,23 @@ export function isSchemaLike(schema: any): schema is LinkedJSONSchema {
   return true
 }
 
+/**
+ * js-yaml@5 loads with CORE_SCHEMA by default, which drops the extra tags that
+ * js-yaml@4's default schema carried. Re-add exactly those tags so that YAML
+ * schemas keep parsing the way they did under js-yaml@4.
+ *
+ * Note that YAML11_SCHEMA is NOT the right choice here: on top of these tags it
+ * also enables the YAML 1.1 scalar notations, under which `y`, `n`, `yes`, `no`,
+ * `on` and `off` resolve to booleans, `0777` is octal, and `12:30` is
+ * sexagesimal. That silently rewrites property names (a property called `y`
+ * becomes `true`) and enum values, which js-yaml@4 never did.
+ */
+const JS_YAML_4_SCHEMA = CORE_SCHEMA.withTags(mergeTag, timestampTag, binaryTag, omapTag, pairsTag, setTag)
+
 export function parseFileAsJSONSchema(filename: string | null, contents: string): JSONSchema4 {
   if (filename != null && isYaml(filename)) {
     return Try(
-      // js-yaml@5 defaults to the YAML 1.2 core schema, which drops merge keys
-      // (`<<`), timestamps, and YAML 1.1 scalar syntax. Keep parsing YAML 1.1 so
-      // that schemas that worked with js-yaml@4 keep working.
-      () => loadYaml(contents.toString(), {schema: YAML11_SCHEMA}) as JSONSchema4,
+      () => loadYaml(contents.toString(), {schema: JS_YAML_4_SCHEMA}) as JSONSchema4,
       () => {
         throw new TypeError(`Error parsing YML in file "${filename}"`)
       },

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -1,6 +1,6 @@
 import test from 'ava'
 import {link} from '../src/linker'
-import {pathTransform, generateName, isSchemaLike} from '../src/utils'
+import {pathTransform, generateName, isSchemaLike, parseFileAsJSONSchema} from '../src/utils'
 
 export function run() {
   test('pathTransform', t => {
@@ -43,5 +43,38 @@ export function run() {
     t.is(isSchemaLike(schema.title), false)
     t.is(isSchemaLike(schema.properties!.firstName), true)
     t.is(isSchemaLike(schema.properties!.lastName), true)
+  })
+  test('parseFileAsJSONSchema does not apply YAML 1.1 scalar resolution', t => {
+    // Under the YAML 1.1 scalar rules, `y`/`n`/`yes`/`no`/`on`/`off` resolve to
+    // booleans, `0777` is octal and `12:30` is sexagesimal. js-yaml@4 did not do
+    // this, and doing it silently rewrites property names and enum values.
+    const schema = parseFileAsJSONSchema(
+      'schema.yaml',
+      [
+        'type: object',
+        'properties:',
+        '  x: {type: number}',
+        '  y: {type: number}',
+        '  n: {type: string}',
+        'required: [x, y, n]',
+        'enum: [yes, no, on, off]',
+        'mode: 0777',
+        'time: 12:30',
+      ].join('\n'),
+    )
+    t.deepEqual(Object.keys(schema.properties!), ['x', 'y', 'n'])
+    t.deepEqual(schema.required, ['x', 'y', 'n'])
+    t.deepEqual(schema.enum, ['yes', 'no', 'on', 'off'])
+    t.is((schema as any).mode, 777)
+    t.is((schema as any).time, '12:30')
+  })
+  test('parseFileAsJSONSchema supports merge keys and timestamps', t => {
+    // Both come from js-yaml@4's default schema, and are not in js-yaml@5's.
+    const schema = parseFileAsJSONSchema(
+      'schema.yaml',
+      ['base: &base {type: string}', 'properties:', '  name:', '    <<: *base', '    default: 2001-12-14'].join('\n'),
+    )
+    t.is(schema.properties!.name.type, 'string')
+    t.true(schema.properties!.name.default instanceof Date)
   })
 }


### PR DESCRIPTION
Follow-up to #686. Not yet published (`package.json` is still at 15.0.3), so this can land before the regression reaches npm.

## The bug

#686 moved YAML parsing to `YAML11_SCHEMA` to restore the tags js-yaml@4's default schema carried (merge keys `<<`, timestamps, binary, omap, pairs, set). But `YAML11_SCHEMA` is a **superset** of js-yaml@4's default: on top of those tags it also enables the YAML 1.1 *scalar* notations, which js-yaml@4 did not.

Under those notations `y`, `n`, `yes`, `no`, `on` and `off` resolve to booleans, `0777` is octal, and `12:30` is sexagesimal. In a JSON Schema that silently rewrites the document. Given:

```yaml
properties:
  x: {type: number}
  y: {type: number}
  n: {type: string}
required: [x, y]
enabled: [yes, no, on, off]
```

| | result |
|---|---|
| js-yaml@4 (v15.0.3) | `properties: {x, y, n}`, `required: ["x","y"]`, `enabled: ["yes","no","on","off"]` |
| master today | `properties: {x, `**`true`**`, `**`false`**`}`, `required: ["x", `**`true`**`]`, `enabled: [`**`true,false,true,false`**`]` |

A property named `y` becomes a property named `true`, and `n` becomes `false`. Both are common property names, and unquoted `yes`/`no`/`on`/`off` in an `enum` is idiomatic YAML — so affected schemas compiled to the wrong TypeScript with no error.

## The fix

Build the js-yaml@4-equivalent schema explicitly, as js-yaml@5's README documents: `CORE_SCHEMA` plus exactly the tags v4 had.

```ts
const JS_YAML_4_SCHEMA = CORE_SCHEMA.withTags(mergeTag, timestampTag, binaryTag, omapTag, pairsTag, setTag)
```

I diffed this against js-yaml@4 on property names, merge keys, timestamps and scalar edge cases (`0777`, `12:30`, `~`, floats) — exact match on all of them, where `YAML11_SCHEMA` differs. Merge-key and timestamp support, which motivated the original change, is preserved.

## Tests

The existing YAML fixtures (`test/resources/Schema.yaml` and friends) use only unambiguous scalars, which is why CI stayed green. This adds two unit tests to `testUtils.ts` covering the 1.1 scalar cases, merge keys and timestamps. Confirmed the first one fails against `YAML11_SCHEMA` with exactly the corruption above, and passes with this fix.

Full suite: 164 passed, no snapshot changes.

## Also

The `ci-ok` aggregate job tested for `'failure'`/`'cancelled'`, so a **skipped** `build` rendered `true` and exited 0 — satisfying branch protection with zero tests run. Since that job exists specifically to be the required check, it now tests for `success` instead, which covers every non-success result.

## Not addressed here

Two other things from the review of #686, left alone since they're judgement calls for you:

- `engines: node >=16` is no longer verified by CI (matrix is 22/24, `.nvmrc` is 24). Either add a 16.x smoke job or raise `engines` — the latter is likely correct and is a semver-major signal.
- Two snapshot hunks in #686 were attributed to prettier union collapsing, but are actually semantic changes — generated JSDoc comments on `Coding1` and `PackageExportsEntryObject1` changed content, from `@apidevtools/json-schema-ref-parser` 11.6.1 → 11.9.3 changing `$ref`-with-sibling-keys handling. Worth noting that `^11.5.5` already allowed 11.9.3, so users installing v15.0.3 today already get that output; the snapshots were masking floating-dependency drift rather than the PR introducing it. May deserve a CHANGELOG line at release time, along with the js-yaml major.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LaDDGTFq3FQZ6t1qMmoMs

---
_Generated by [Claude Code](https://claude.ai/code/session_017LaDDGTFq3FQZ6t1qMmoMs)_