### PR TITLE
Add an end-to-end fuzz harness

### DIFF
--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -1,0 +1,61 @@
+# Fuzz harness
+
+An end-to-end fuzzer for `compile()`. It generates plausible JSON Schemas, compiles
+each one in a child process under a wall-clock timeout and a heap cap, and reports
+what broke.
+
+The generator is deliberately biased toward schemas a person could actually write —
+bounded depth, bounded node counts, realistic keyword combinations. The goal is bugs
+that show up in practice, not what happens at 10,000 levels of nesting.
+
+## Running it
+
+```bash
+npm run build:server                       # the harness runs against dist/
+node test/fuzz/fuzz.js --seeds 300 --out findings.json
+```
+
+Useful flags:
+
+| Flag | Meaning |
+| --- | --- |
+| `--seeds N` | how many cases to generate (default 300) |
+| `--start N` | first seed, so runs can cover different ranges (default 1) |
+| `--timeout MS` | per-case wall clock before a case counts as a hang (default 20000) |
+| `--memory MB` | per-case heap cap (default 512) |
+| `--seed N` | re-run a single seed and dump its schema, options, and result |
+| `--no-shrink` | skip minimization (much faster, much noisier) |
+| `--out FILE` | write the JSON report here instead of stdout |
+
+Every case is derived from its seed, so `--seed 27` reproduces case 27 exactly.
+
+## What it classifies
+
+| Status | Meaning |
+| --- | --- |
+| `TIMEOUT` | compile did not finish in time — excessive CPU |
+| `OOM` | the child exhausted its heap cap |
+| `STACK_OVERFLOW` | unbounded recursion |
+| `THREW` | an unexpected exception (`ValidationError` is expected, and ignored) |
+| `INVALID_TS` | compile succeeded but emitted TypeScript that does not parse |
+
+`INVALID_TS` matters because nothing throws in that case: the compiler reports
+success and hands back code that breaks the consumer's build. The check parses the
+output with the TypeScript compiler and reports syntactic diagnostics.
+
+## Shrinking
+
+A raw fuzz case is too noisy to act on, so each distinct finding is minimized before
+it is reported: options are dropped one at a time, then subtrees are deleted,
+replaced with `{type: 'string'}`, or emptied — keeping any reduction that preserves
+the failure signature. Findings are deduped by signature first, so a bug that fires
+on 50 seeds is shrunk once.
+
+## Notes
+
+- External `$ref` resolution is disabled for every generated case (`resolve: {file:
+  false, http: false}`). A fuzzed schema must never reach the network or the
+  filesystem.
+- These files are `.js` on purpose. The repository's `.gitignore` excludes `*.js`,
+  so they were added with `git add -f`; keeping them out of the TypeScript build
+  means the harness cannot break `npm test`.

--- a/test/fuzz/fuzz.js
+++ b/test/fuzz/fuzz.js
@@ -1,0 +1,366 @@
+#!/usr/bin/env node
+/**
+ * End-to-end fuzzer for json-schema-to-typescript.
+ *
+ * Generates plausible JSON Schemas, compiles each one in a child process with a
+ * wall-clock timeout and a heap cap, and classifies the failures that come back:
+ *
+ *   TIMEOUT         compile did not finish in time — excessive CPU
+ *   OOM             child exhausted the heap cap
+ *   STACK_OVERFLOW  unbounded recursion
+ *   THREW           an unexpected exception (ValidationError is expected, not a bug)
+ *   INVALID_TS      compile succeeded but emitted syntactically invalid TypeScript
+ *
+ * Findings are deduped by signature and then shrunk to a minimal reproducing
+ * schema, because an unshrunk fuzz case is not something a maintainer can act on.
+ *
+ * Usage:
+ *   node test/fuzz/fuzz.js --seeds 500 --out findings.json
+ *   node test/fuzz/fuzz.js --seed 12345          # re-run one case
+ */
+
+const {spawnSync} = require('child_process')
+const {writeFileSync, mkdtempSync, rmSync} = require('fs')
+const {tmpdir} = require('os')
+const {join, resolve} = require('path')
+const {generateSchema, generateOptions} = require('./schemaGen')
+
+const RUN_CASE = resolve(__dirname, 'runCase.js')
+
+// Errors the library raises on purpose. Not bugs.
+const EXPECTED_ERRORS = ['ValidationError']
+
+function parseArgs(argv) {
+  const args = {seeds: 300, start: 1, timeout: 20000, memory: 512, out: null, seed: null, shrink: true, quiet: false}
+  for (let i = 2; i < argv.length; i++) {
+    const [k, v] = argv[i].includes('=') ? argv[i].split('=') : [argv[i], argv[i + 1]]
+    switch (k) {
+      case '--seeds':
+        args.seeds = Number(v)
+        if (!argv[i].includes('=')) i++
+        break
+      case '--start':
+        args.start = Number(v)
+        if (!argv[i].includes('=')) i++
+        break
+      case '--timeout':
+        args.timeout = Number(v)
+        if (!argv[i].includes('=')) i++
+        break
+      case '--memory':
+        args.memory = Number(v)
+        if (!argv[i].includes('=')) i++
+        break
+      case '--out':
+        args.out = v
+        if (!argv[i].includes('=')) i++
+        break
+      case '--seed':
+        args.seed = Number(v)
+        if (!argv[i].includes('=')) i++
+        break
+      case '--no-shrink':
+        args.shrink = false
+        break
+      case '--quiet':
+        args.quiet = true
+        break
+    }
+  }
+  return args
+}
+
+const workDir = mkdtempSync(join(tmpdir(), 'jstt-fuzz-'))
+let caseCounter = 0
+
+/** Run one (schema, options) pair in a child process and classify the outcome. */
+function runCase(schema, options, {timeout, memory}) {
+  const casePath = join(workDir, `case-${caseCounter++}.json`)
+  writeFileSync(casePath, JSON.stringify({schema, options}))
+
+  const started = Date.now()
+  const child = spawnSync(process.execPath, [`--max-old-space-size=${memory}`, RUN_CASE, casePath], {
+    timeout,
+    encoding: 'utf-8',
+    maxBuffer: 32 * 1024 * 1024,
+    killSignal: 'SIGKILL',
+  })
+  const elapsed = Date.now() - started
+
+  if (child.error && child.error.code === 'ETIMEDOUT') {
+    return {status: 'TIMEOUT', errorName: 'Timeout', message: `exceeded ${timeout}ms`, frame: '', elapsed}
+  }
+
+  const stderr = child.stderr || ''
+  if (/JavaScript heap out of memory|Allocation failed|FATAL ERROR: .*heap/i.test(stderr)) {
+    return {status: 'OOM', errorName: 'OutOfMemory', message: `exceeded ${memory}MB heap`, frame: '', elapsed}
+  }
+
+  const marker = (child.stdout || '').split('\n').find(l => l.startsWith('__FUZZ_RESULT__'))
+  if (!marker) {
+    if (/Maximum call stack size exceeded/.test(stderr)) {
+      return {status: 'STACK_OVERFLOW', errorName: 'RangeError', message: 'Maximum call stack size exceeded', frame: '', elapsed}
+    }
+    return {
+      status: 'CRASHED',
+      errorName: 'ProcessCrash',
+      message: `exit ${child.status} signal ${child.signal}: ${stderr.slice(0, 300)}`,
+      frame: '',
+      elapsed,
+    }
+  }
+
+  const result = JSON.parse(marker.slice('__FUZZ_RESULT__'.length).trim())
+  result.elapsed = elapsed
+
+  if (result.status === 'THREW' && /Maximum call stack size exceeded/.test(result.message)) {
+    result.status = 'STACK_OVERFLOW'
+  }
+  return result
+}
+
+function isInteresting(result) {
+  if (result.status === 'OK') return false
+  if (result.status === 'HARNESS_ERROR') return false
+  if (result.status === 'THREW' && EXPECTED_ERRORS.includes(result.errorName)) return false
+  return true
+}
+
+function signature(result) {
+  if (result.status === 'TIMEOUT' || result.status === 'OOM') return result.status
+  if (result.status === 'INVALID_TS') {
+    // Group by the diagnostic itself, minus the quoted source text.
+    return `INVALID_TS:${result.message.split('(line')[0].trim()}`
+  }
+  return `${result.status}:${result.errorName}:${result.frame}:${result.message.slice(0, 60)}`
+}
+
+// ---------------------------------------------------------------------------
+// Shrinking
+// ---------------------------------------------------------------------------
+
+const clone = x => JSON.parse(JSON.stringify(x))
+
+/** Every path in the schema tree, deepest first (deep edits shrink faster). */
+function collectPaths(node, path = [], out = []) {
+  if (node === null || typeof node !== 'object') return out
+  for (const key of Object.keys(node)) {
+    const child = node[key]
+    collectPaths(child, path.concat(key), out)
+    out.push(path.concat(key))
+  }
+  return out
+}
+
+function getAt(obj, path) {
+  return path.reduce((o, k) => (o == null ? o : o[k]), obj)
+}
+
+function setAt(obj, path, value) {
+  const parent = getAt(obj, path.slice(0, -1))
+  if (parent == null) return false
+  parent[path[path.length - 1]] = value
+  return true
+}
+
+function deleteAt(obj, path) {
+  const parent = getAt(obj, path.slice(0, -1))
+  if (parent == null) return false
+  const key = path[path.length - 1]
+  if (Array.isArray(parent)) {
+    const i = Number(key)
+    if (Number.isNaN(i)) return false
+    parent.splice(i, 1)
+  } else {
+    delete parent[key]
+  }
+  return true
+}
+
+/** Candidate reductions, cheapest and most aggressive first. */
+function* candidates(schema, options) {
+  // Drop options one at a time — a bug that needs fewer flags is a better report.
+  for (const key of Object.keys(options)) {
+    if (key === '$refOptions') continue
+    const o = clone(options)
+    delete o[key]
+    yield {schema, options: o}
+  }
+
+  const paths = collectPaths(schema)
+  for (const path of paths) {
+    const key = path[path.length - 1]
+    if (key === '$schema') continue
+
+    const deleted = clone(schema)
+    if (deleteAt(deleted, path)) yield {schema: deleted, options}
+
+    const node = getAt(schema, path)
+    if (node !== null && typeof node === 'object') {
+      const simplified = clone(schema)
+      if (setAt(simplified, path, {type: 'string'})) yield {schema: simplified, options}
+      const emptied = clone(schema)
+      if (setAt(emptied, path, {})) yield {schema: emptied, options}
+    }
+    if (typeof node === 'number' && node > 0) {
+      for (const smaller of [0, 1, Math.floor(node / 2)]) {
+        if (smaller >= node) continue
+        const reduced = clone(schema)
+        if (setAt(reduced, path, smaller)) yield {schema: reduced, options}
+      }
+    }
+    if (typeof node === 'string' && node.length > 8) {
+      const shortened = clone(schema)
+      if (setAt(shortened, path, 'x')) yield {schema: shortened, options}
+    }
+  }
+}
+
+/**
+ * Greedily reduce the case while the failure signature holds. Bounded by a step
+ * budget so a slow signature (a timeout, say) cannot run forever.
+ */
+function shrink(schema, options, targetSig, runOpts, budget) {
+  let best = {schema: clone(schema), options: clone(options)}
+  let steps = 0
+  let improved = true
+
+  while (improved && steps < budget) {
+    improved = false
+    for (const candidate of candidates(best.schema, best.options)) {
+      if (steps++ >= budget) break
+      let result
+      try {
+        result = runCase(candidate.schema, candidate.options, runOpts)
+      } catch {
+        continue
+      }
+      if (isInteresting(result) && signature(result) === targetSig) {
+        best = {schema: clone(candidate.schema), options: clone(candidate.options)}
+        improved = true
+        break
+      }
+    }
+  }
+  return {...best, shrinkSteps: steps}
+}
+
+// ---------------------------------------------------------------------------
+// Severity — keeps the report focused on things that bite real users
+// ---------------------------------------------------------------------------
+
+function severity(finding) {
+  const size = JSON.stringify(finding.schema).length
+  switch (finding.status) {
+    case 'OOM':
+    case 'TIMEOUT':
+      // A small schema that burns the CPU or the heap is the worst case: it looks
+      // ordinary and hangs a build. A huge one is far less likely in practice.
+      return size < 400 ? 'high' : 'medium'
+    case 'INVALID_TS':
+      return 'high' // emitted code does not compile — breaks the consumer's build
+    case 'STACK_OVERFLOW':
+    case 'CRASHED':
+      return 'high'
+    case 'THREW':
+      return ['TypeError', 'RangeError', 'ReferenceError'].includes(finding.errorName) ? 'high' : 'medium'
+    default:
+      return 'low'
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = parseArgs(process.argv)
+  const runOpts = {timeout: args.timeout, memory: args.memory}
+  const log = (...a) => !args.quiet && console.log(...a)
+
+  if (args.seed !== null) {
+    const schema = generateSchema(args.seed)
+    const options = generateOptions(args.seed)
+    console.log(JSON.stringify({seed: args.seed, schema, options}, null, 2))
+    console.log(JSON.stringify(runCase(schema, options, runOpts), null, 2))
+    return
+  }
+
+  const findings = new Map()
+  let ran = 0
+
+  log(`fuzzing seeds ${args.start}..${args.start + args.seeds - 1} (timeout ${args.timeout}ms, heap ${args.memory}MB)`)
+
+  for (let i = 0; i < args.seeds; i++) {
+    const seed = args.start + i
+    const schema = generateSchema(seed)
+    const options = generateOptions(seed)
+    let result
+    try {
+      result = runCase(schema, options, runOpts)
+    } catch (e) {
+      continue
+    }
+    ran++
+
+    if (!isInteresting(result)) continue
+    const sig = signature(result)
+    if (findings.has(sig)) {
+      findings.get(sig).count++
+      continue
+    }
+
+    log(`  [seed ${seed}] ${result.status} ${result.errorName} ${result.message.slice(0, 80)}`)
+    findings.set(sig, {signature: sig, seed, count: 1, ...result, schema, options})
+  }
+
+  log(`\nran ${ran} cases, ${findings.size} distinct findings`)
+
+  const out = []
+  for (const finding of findings.values()) {
+    let minimized = {schema: finding.schema, options: finding.options, shrinkSteps: 0}
+    if (args.shrink) {
+      // Timeout signatures cost a full timeout per probe, so give them less rope.
+      const budget = finding.status === 'TIMEOUT' || finding.status === 'OOM' ? 60 : 400
+      log(`shrinking ${finding.signature.slice(0, 70)} (budget ${budget})...`)
+      minimized = shrink(finding.schema, finding.options, finding.signature, runOpts, budget)
+    }
+    const entry = {
+      signature: finding.signature,
+      status: finding.status,
+      errorName: finding.errorName,
+      message: finding.message,
+      frame: finding.frame,
+      seed: finding.seed,
+      occurrences: finding.count,
+      elapsedMs: finding.elapsed,
+      schema: minimized.schema,
+      options: minimized.options,
+      shrinkSteps: minimized.shrinkSteps,
+    }
+    entry.severity = severity(entry)
+    out.push(entry)
+  }
+
+  out.sort((a, b) => (a.severity === b.severity ? b.occurrences - a.occurrences : a.severity === 'high' ? -1 : 1))
+
+  const report = {
+    ranAt: new Date().toISOString(),
+    seedRange: [args.start, args.start + args.seeds - 1],
+    casesRun: ran,
+    findings: out,
+  }
+
+  if (args.out) {
+    writeFileSync(args.out, JSON.stringify(report, null, 2))
+    log(`wrote ${args.out}`)
+  } else {
+    console.log(JSON.stringify(report, null, 2))
+  }
+
+  try {
+    rmSync(workDir, {recursive: true, force: true})
+  } catch {
+    /* best effort */
+  }
+}
+
+main()

--- a/test/fuzz/runCase.js
+++ b/test/fuzz/runCase.js
@@ -1,0 +1,92 @@
+/**
+ * Runs a single fuzz case in isolation.
+ *
+ * Lives in its own process so the parent can survive (and classify) an OOM, a
+ * stack overflow, or a hang that would otherwise take the whole run down.
+ *
+ * Usage: node runCase.js <path-to-case.json>
+ * Emits one line: __FUZZ_RESULT__ <json>
+ */
+
+const {readFileSync} = require('fs')
+const {resolve} = require('path')
+
+const DIST = resolve(__dirname, '../../dist/src/index.js')
+
+async function main() {
+  const casePath = process.argv[2]
+  const {schema, options} = JSON.parse(readFileSync(casePath, 'utf-8'))
+  const {compile} = require(DIST)
+
+  let ts
+  try {
+    ts = await compile(schema, 'FuzzRoot', options)
+  } catch (e) {
+    return {
+      status: 'THREW',
+      errorName: e && e.constructor ? e.constructor.name : typeof e,
+      message: e && e.message ? String(e.message).slice(0, 400) : String(e).slice(0, 400),
+      frame: topFrame(e),
+    }
+  }
+
+  // The compiler succeeded, but did it emit valid TypeScript? Syntactically broken
+  // output is a real bug even though nothing threw — and with `format: false`
+  // there is no Prettier parse to catch it.
+  const syntaxError = findSyntaxError(ts)
+  if (syntaxError) {
+    return {status: 'INVALID_TS', errorName: 'SyntaxError', message: syntaxError, frame: ''}
+  }
+
+  return {status: 'OK'}
+}
+
+function topFrame(e) {
+  if (!e || !e.stack) return ''
+  const lines = String(e.stack).split('\n')
+  for (const line of lines) {
+    const m = line.match(/\((.*?)\)\s*$/) || line.match(/at\s+(.*)$/)
+    if (!m) continue
+    // First frame inside the library itself is the useful one for deduping.
+    if (m[1].includes('/dist/src/')) {
+      return m[1].replace(/^.*\/dist\/src\//, 'src/')
+    }
+  }
+  return ''
+}
+
+function findSyntaxError(ts) {
+  let typescript
+  try {
+    typescript = require('typescript')
+  } catch {
+    return null // TypeScript unavailable; skip this check rather than fail the case.
+  }
+  const sourceFile = typescript.createSourceFile('fuzz.ts', ts, typescript.ScriptTarget.Latest, true)
+  const diagnostics = sourceFile.parseDiagnostics || []
+  if (!diagnostics.length) return null
+  const d = diagnostics[0]
+  const text = typescript.flattenDiagnosticMessageText(d.messageText, ' ')
+  const {line} = sourceFile.getLineAndCharacterOfPosition(d.start || 0)
+  const offending = ts.split('\n')[line] || ''
+  return `${text} (line ${line + 1}: ${offending.trim().slice(0, 120)})`
+}
+
+main().then(
+  result => {
+    process.stdout.write('__FUZZ_RESULT__ ' + JSON.stringify(result) + '\n')
+  },
+  e => {
+    // A rejection from our own harness, not from the library under test.
+    process.stdout.write(
+      '__FUZZ_RESULT__ ' +
+        JSON.stringify({
+          status: 'HARNESS_ERROR',
+          errorName: 'HarnessError',
+          message: String((e && e.message) || e).slice(0, 400),
+          frame: '',
+        }) +
+        '\n',
+    )
+  },
+)

--- a/test/fuzz/schemaGen.js
+++ b/test/fuzz/schemaGen.js
@@ -1,0 +1,261 @@
+/**
+ * Structure-aware JSON Schema generator for fuzzing.
+ *
+ * Deliberately biased toward schemas a real user could plausibly write: bounded
+ * depth, bounded node counts, realistic keyword combinations. We are looking for
+ * bugs that show up in practice, not for what happens at 10,000 levels of nesting.
+ */
+
+// mulberry32 — small, fast, seedable, so every finding is reproducible from its seed.
+function makeRng(seed) {
+  let a = seed >>> 0
+  return function rng() {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = a
+    t = Math.imul(t ^ (t >>> 15), t | 1)
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61)
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const pick = (rng, xs) => xs[Math.floor(rng() * xs.length)]
+const chance = (rng, p) => rng() < p
+
+// Names that stress identifier handling — all of them are legal JSON Schema
+// property names, and all of them turn up in real-world schemas.
+const PROP_NAMES = [
+  'id',
+  'name',
+  'type',
+  'value',
+  'items',
+  'x-custom',
+  'kebab-case-name',
+  'dotted.name',
+  'with space',
+  'with"quote',
+  "with'quote",
+  'with`backtick',
+  '0leadingDigit',
+  'constructor',
+  '__proto__',
+  'prototype',
+  'toString',
+  'class',
+  'function',
+  'default',
+  'Ünïcödé',
+  '日本語',
+  '🎉emoji',
+  '',
+]
+
+// Strings that stress comment/JSDoc emission. `*/` in a description can close the
+// generated block comment early; newlines and backticks matter for template output.
+const TEXTS = [
+  'a simple description',
+  'ends a comment: */ and keeps going',
+  'nested /* comment */ here',
+  'line one\nline two',
+  'tab\there',
+  'back`tick and ${interpolation}',
+  'quote " and \' mixed',
+  'unicode ✨ 日本語 🎉',
+  'a'.repeat(200),
+]
+
+const FORMATS = ['date-time', 'email', 'uri', 'uuid', 'ipv4', 'unknown-format']
+
+function randomText(rng) {
+  return pick(rng, TEXTS)
+}
+
+function randomPropName(rng) {
+  return pick(rng, PROP_NAMES)
+}
+
+function maybeAnnotate(rng, schema) {
+  if (chance(rng, 0.25)) schema.title = randomText(rng)
+  if (chance(rng, 0.3)) schema.description = randomText(rng)
+  if (chance(rng, 0.08)) schema.default = pick(rng, [null, 0, '', false, {}, []])
+  return schema
+}
+
+function genEnum(rng) {
+  const kind = pick(rng, ['strings', 'mixed', 'numbers', 'withNull', 'objects'])
+  let values
+  switch (kind) {
+    case 'strings':
+      values = ['a', 'b', 'c'].slice(0, 1 + Math.floor(rng() * 3))
+      break
+    case 'mixed':
+      values = ['a', 1, true, null]
+      break
+    case 'numbers':
+      values = [0, 1, 2]
+      break
+    case 'withNull':
+      values = [null, 'x']
+      break
+    default:
+      values = [{a: 1}, [1, 2]]
+      break
+  }
+  const schema = {enum: values}
+  if (chance(rng, 0.3)) schema.type = 'string'
+  // tsEnumNames is an extension; a length mismatch is an easy real-world mistake.
+  if (chance(rng, 0.25)) {
+    schema.tsEnumNames = values.map((_, i) => `Name${i}`)
+    if (chance(rng, 0.3)) schema.tsEnumNames.pop()
+  }
+  return maybeAnnotate(rng, schema)
+}
+
+function genArray(rng, depth, ctx) {
+  const schema = {type: 'array'}
+  const style = pick(rng, ['items', 'tuple', 'tupleAdditional', 'bare'])
+  if (style === 'items') {
+    schema.items = genSchema(rng, depth + 1, ctx)
+  } else if (style === 'tuple' || style === 'tupleAdditional') {
+    const n = 1 + Math.floor(rng() * 3)
+    schema.items = Array.from({length: n}, () => genSchema(rng, depth + 1, ctx))
+    if (style === 'tupleAdditional') {
+      schema.additionalItems = chance(rng, 0.5) ? genSchema(rng, depth + 1, ctx) : false
+    }
+  }
+  // minItems/maxItems drive tuple expansion in the generator, which is the most
+  // plausible real-world source of a CPU/memory blowup. Keep the values in the
+  // range a human would actually write.
+  if (chance(rng, 0.45)) {
+    const min = Math.floor(rng() * 8)
+    schema.minItems = min
+    if (chance(rng, 0.7)) {
+      schema.maxItems = min + Math.floor(rng() * 25)
+    }
+  }
+  if (chance(rng, 0.1)) schema.uniqueItems = true
+  return maybeAnnotate(rng, schema)
+}
+
+function genObject(rng, depth, ctx) {
+  const schema = {type: 'object'}
+  const propCount = Math.floor(rng() * 4)
+  if (propCount > 0) {
+    schema.properties = {}
+    const used = new Set()
+    for (let i = 0; i < propCount; i++) {
+      let key = randomPropName(rng)
+      if (used.has(key)) key = key + i
+      used.add(key)
+      schema.properties[key] = genSchema(rng, depth + 1, ctx)
+    }
+    if (chance(rng, 0.5)) {
+      schema.required = Object.keys(schema.properties).filter(() => chance(rng, 0.5))
+    }
+  }
+  if (chance(rng, 0.2)) {
+    schema.patternProperties = {
+      [pick(rng, ['^x-', '^[a-z]+$', '.*', '^\\d+$'])]: genSchema(rng, depth + 1, ctx),
+    }
+  }
+  if (chance(rng, 0.35)) {
+    schema.additionalProperties = chance(rng, 0.5) ? false : genSchema(rng, depth + 1, ctx)
+  }
+  return maybeAnnotate(rng, schema)
+}
+
+function genCombinator(rng, depth, ctx) {
+  const key = pick(rng, ['allOf', 'anyOf', 'oneOf'])
+  const n = 2 + Math.floor(rng() * 2)
+  const schema = {[key]: Array.from({length: n}, () => genSchema(rng, depth + 1, ctx))}
+  if (chance(rng, 0.2)) schema.type = 'object'
+  return maybeAnnotate(rng, schema)
+}
+
+function genRef(rng, ctx) {
+  // Only internal refs. External refs are never fuzzed: resolving them would mean
+  // touching the network or the filesystem.
+  if (ctx.defNames.length === 0) return {type: 'string'}
+  return {$ref: `#/definitions/${pick(rng, ctx.defNames)}`}
+}
+
+function genSchema(rng, depth, ctx) {
+  ctx.nodes++
+  // Bounded on purpose: past this point we would be testing pathological input
+  // rather than anything a user would hand the compiler.
+  if (depth >= ctx.maxDepth || ctx.nodes > ctx.maxNodes) {
+    return {type: pick(rng, ['string', 'number', 'boolean', 'null'])}
+  }
+
+  const roll = rng()
+  if (roll < 0.22) {
+    const schema = {type: pick(rng, ['string', 'number', 'integer', 'boolean', 'null'])}
+    if (schema.type === 'string' && chance(rng, 0.3)) schema.format = pick(rng, FORMATS)
+    if (schema.type === 'string' && chance(rng, 0.15)) schema.pattern = pick(rng, ['^a+$', '\\d+', '.*'])
+    return maybeAnnotate(rng, schema)
+  }
+  if (roll < 0.3) return genEnum(rng)
+  if (roll < 0.36) return maybeAnnotate(rng, {const: pick(rng, ['foo', 1, true, null])})
+  if (roll < 0.52) return genObject(rng, depth, ctx)
+  if (roll < 0.66) return genArray(rng, depth, ctx)
+  if (roll < 0.78) return genCombinator(rng, depth, ctx)
+  if (roll < 0.84) return genRef(rng, ctx)
+  if (roll < 0.88) return maybeAnnotate(rng, {not: genSchema(rng, depth + 1, ctx)})
+  if (roll < 0.92) return maybeAnnotate(rng, {type: ['string', 'null']})
+  if (roll < 0.95) return maybeAnnotate(rng, {tsType: pick(rng, ['MyType', 'string[]', 'Record<string, unknown>'])})
+  if (roll < 0.97) return true
+  if (roll < 0.98) return false
+  return {}
+}
+
+/** Generate a complete root schema for a given seed. */
+function generateSchema(seed) {
+  const rng = makeRng(seed)
+  const ctx = {defNames: [], nodes: 0, maxDepth: 5, maxNodes: 60}
+
+  const root = {$schema: 'http://json-schema.org/draft-07/schema#'}
+
+  // Definitions first, so refs elsewhere have something to point at. Self-refs are
+  // allowed and intentional: recursive schemas are extremely common in practice.
+  const defCount = Math.floor(rng() * 4)
+  if (defCount > 0) {
+    root.definitions = {}
+    for (let i = 0; i < defCount; i++) {
+      const name = pick(rng, ['Node', 'Item', 'Base', 'Entity', 'Ref']) + i
+      ctx.defNames.push(name)
+      root.definitions[name] = genSchema(rng, 1, ctx)
+    }
+  }
+
+  const body = genSchema(rng, 0, ctx)
+  if (typeof body === 'object' && body !== null && !Array.isArray(body)) {
+    Object.assign(root, body)
+  } else {
+    root.type = 'object'
+  }
+  if (!root.type && !root.allOf && !root.anyOf && !root.oneOf && !root.$ref && !root.enum) {
+    root.type = 'object'
+  }
+  return root
+}
+
+/** Generate an options object for a given seed. */
+function generateOptions(seed) {
+  const rng = makeRng(seed ^ 0x9e3779b9)
+  const options = {
+    // Never let a fuzzed schema reach the network or the filesystem.
+    $refOptions: {resolve: {file: false, http: false}},
+  }
+  if (chance(rng, 0.5)) options.format = false
+  if (chance(rng, 0.3)) options.unreachableDefinitions = true
+  if (chance(rng, 0.3)) options.inferStringEnumKeysFromValues = true
+  if (chance(rng, 0.25)) options.strictIndexSignatures = true
+  if (chance(rng, 0.25)) options.unknownAny = false
+  if (chance(rng, 0.25)) options.enableConstEnums = false
+  if (chance(rng, 0.25)) options.additionalProperties = false
+  if (chance(rng, 0.2)) options.ignoreMinAndMaxItems = true
+  if (chance(rng, 0.3)) options.maxItems = pick(rng, [-1, 0, 1, 5, 20, 100])
+  return options
+}
+
+module.exports = {generateSchema, generateOptions, makeRng}


### PR DESCRIPTION
Adds `test/fuzz/` — the harness that found #690, #691, and #692.

It generates plausible JSON Schemas, compiles each one in a child process under a wall-clock timeout and a heap cap, and classifies what comes back:

| Status | Meaning |
| --- | --- |
| `TIMEOUT` | compile did not finish in time — excessive CPU |
| `OOM` | the child exhausted its heap cap |
| `STACK_OVERFLOW` | unbounded recursion |
| `THREW` | an unexpected exception (`ValidationError` is expected, and ignored) |
| `INVALID_TS` | compile succeeded but emitted TypeScript that does not parse |

`INVALID_TS` is the one that pays for itself: nothing throws, so `compile()` reports success and hands back code that breaks the consumer's build. The check parses the output with the repo's own `typescript` dependency. Two of the three issues above are in that category.

## Design notes

- **Bounded generation.** Depth, node count, and keyword combinations are capped so findings correspond to schemas someone could plausibly write. The goal is bugs that show up in practice, not what happens at 10,000 levels of nesting.
- **Seeded and reproducible.** Every case derives from its seed, so `--seed 27` reproduces case 27 exactly.
- **Shrinking.** A raw fuzz case is too noisy to act on, so each distinct finding is minimized — options dropped one at a time, then subtrees deleted, replaced, or emptied, keeping any reduction that preserves the failure signature. Findings are deduped by signature first, so a bug hitting 50 seeds is shrunk once.
- **No network, no filesystem.** External `$ref` resolution is disabled for every generated case (`resolve: {file: false, http: false}`).

## Usage

```bash
npm run build:server
node test/fuzz/fuzz.js --seeds 300 --out findings.json
```

See `test/fuzz/README.md` for flags.

## Why these files are `.js`

`.gitignore` excludes `*.js`, so they were added with `git add -f`. Keeping the harness out of the TypeScript build is deliberate: it cannot break `npm test`, and `tsconfig.json` has no `allowJs`, so `tsc` ignores it entirely. Nothing in `npm test`, `npm run lint`, or `npm run format-check` touches these files. Happy to port them to TypeScript under `test/` instead if you'd rather they were type-checked.

## Testing

Additive only — no existing file is modified. Full suite still passes at 163 tests. The run that produced #690–#692 covered 400 seeds and returned 10 distinct findings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSm7rJFS6NskKPbvAvy4nQ)_