### PR TITLE
Fix explicit false for style.singleQuote CLI option

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ main(
       'enableConstEnums',
       'format',
       'ignoreMinAndMaxItems',
+      'style.singleQuote',
       'strictIndexSignatures',
       'unknownAny',
       'unreachableDefinitions',

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -50,6 +50,17 @@ suite('CLI', () => {
     ).toMatchSnapshot()
   })
 
+  test('file in (-i), style boolean with explicit false value, pipe out', () => {
+    const expected = execSync('node dist/src/cli.js -i ./test/resources/Enum.json --no-style.singleQuote').toString()
+
+    expect(execSync('node dist/src/cli.js -i ./test/resources/Enum.json --style.singleQuote false').toString()).toBe(
+      expected,
+    )
+    expect(execSync('node dist/src/cli.js -i ./test/resources/Enum.json --style.singleQuote=false').toString()).toBe(
+      expected,
+    )
+  })
+
   test('file in (-i), pipe out (absolute path)', () => {
     expect(execSync(`node dist/src/cli.js -i ${__dirname}/resources/ReferencedType.json`).toString()).toMatchSnapshot()
   })


### PR DESCRIPTION
## Summary

- declare `style.singleQuote` as a boolean in the minimist configuration
- cover both `--style.singleQuote false` and `--style.singleQuote=false`

## Root cause

Top-level boolean options were declared to minimist, but `style.singleQuote` was not. Explicit false values therefore reached Prettier as the string `"false"`, which Prettier rejected.

The regression test fails on the unfixed source with `Invalid singleQuote value` and passes after the boolean declaration is added.

## Verification

- `npm run pre-test`
- `npm run lint`
- `npx --yes bun test --timeout 300000` — 172 tests passed
- `git diff --check`

Fixes #199