### PR TITLE
Widen compile()'s schema parameter to accept JSONSchema6/7

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import {readFileSync} from 'fs'
-import {JSONSchema4} from 'json-schema'
+import {JSONSchema4, JSONSchema6, JSONSchema7} from 'json-schema'
 import {ParserOptions as $RefOptions} from '@apidevtools/json-schema-ref-parser'
 import {cloneDeep, endsWith, merge} from 'lodash'
 import {dirname} from 'path'
@@ -135,7 +135,11 @@ function parseAsJSONSchema(filename: string): JSONSchema4 {
   return parseFileAsJSONSchema(filename, contents.toString())
 }
 
-export async function compile(schema: JSONSchema4, name: string, options: Partial<Options> = {}): Promise<string> {
+export async function compile(
+  schema: JSONSchema4 | JSONSchema6 | JSONSchema7,
+  name: string,
+  options: Partial<Options> = {},
+): Promise<string> {
   validateOptions(options)
 
   const _options = merge({}, DEFAULT_OPTIONS, options)
@@ -150,8 +154,11 @@ export async function compile(schema: JSONSchema4, name: string, options: Partia
     _options.cwd += '/'
   }
 
-  // Initial clone to avoid mutating the input
-  const _schema = cloneDeep(schema)
+  // Initial clone to avoid mutating the input. Downstream code reads schema
+  // keys generically rather than validating them against a specific draft's
+  // shape (e.g. `exclusiveMaximum` is never interpreted as a boolean vs. a
+  // number), so this cast doesn't change runtime behavior -- see #359.
+  const _schema = cloneDeep(schema) as JSONSchema4
 
   const {dereferencedPaths, dereferencedSchema} = await dereference(_schema, _options)
   if (process.env.VERBOSE) {

--- a/test/schemaVersions.test.ts
+++ b/test/schemaVersions.test.ts
@@ -1,0 +1,28 @@
+import {describe, expect, test} from 'bun:test'
+import {JSONSchema4, JSONSchema6, JSONSchema7} from 'json-schema'
+import {compile} from '../src'
+import {hasOnly} from './e2eCases'
+
+const suite = hasOnly() ? describe.skip : describe
+
+// Regression test for https://github.com/bcherny/json-schema-to-typescript/issues/359:
+// compile()'s `schema` parameter must accept JSONSchema4, JSONSchema6, and JSONSchema7.
+// Draft-06+ types exclusiveMinimum/exclusiveMaximum as numbers, which isn't assignable
+// to draft-04's boolean type -- if compile()'s signature regresses to JSONSchema4 only,
+// this file fails `npm run typecheck` even before any assertion below runs.
+suite('compile() accepts schemas from any supported JSON Schema draft', () => {
+  test('JSONSchema4', async () => {
+    const schema: JSONSchema4 = {type: 'number', exclusiveMaximum: true, maximum: 10}
+    expect(await compile(schema, 'Test')).toContain('export type Test = number')
+  })
+
+  test('JSONSchema6', async () => {
+    const schema: JSONSchema6 = {type: 'number', exclusiveMaximum: 10}
+    expect(await compile(schema, 'Test')).toContain('export type Test = number')
+  })
+
+  test('JSONSchema7', async () => {
+    const schema: JSONSchema7 = {type: 'number', exclusiveMaximum: 10}
+    expect(await compile(schema, 'Test')).toContain('export type Test = number')
+  })
+})


### PR DESCRIPTION
Fixes #359.

`compile`'s parameter type was `JSONSchema4` only, so a `JSONSchema7`-typed schema (e.g. one with a numeric `exclusiveMaximum`) failed to typecheck. Runtime code never interprets `exclusiveMaximum`/`exclusiveMinimum` against a specific draft's shape (they're only ever traversed generically), so widening the parameter type to `JSONSchema4 | JSONSchema6 | JSONSchema7` and casting internally is type-only and doesn't change behavior.

Does not cover `compileFromFile`, which takes a filename rather than a typed schema object, so it isn't affected by this issue.

Regression test: `test/schemaVersions.test.ts`.

auto-fix-bot:issue-359

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrKCYSvUKCae9aTzp6zCYT)_