### PR TITLE
Fix silent file overwrite from extra positional CLI args

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,17 @@ async function main(argv: minimist.ParsedArgs) {
     process.exit(0)
   }
 
+  // Defend against unquoted glob expansion (or other shell mistakes) silently supplying extra
+  // positional arguments. Without this check, argv._[0]/argv._[1] would silently win over an
+  // explicitly-passed --input/--output flag, or overflow past the two positional slots (input,
+  // output) this CLI supports -- either way risking a source file being misread as an output
+  // path and overwritten.
+  if (argv._.length > 2 || (argv._.length > 0 && (argv.input !== undefined || argv.output !== undefined))) {
+    throw new ReferenceError(
+      `Unexpected extra argument(s): ${argv._.join(', ')}. json-schema-to-typescript accepts at most one input path and one output path. If you passed a glob to --input, quote it (e.g. -i "schemas/**/*.json") so your shell doesn't expand it first.`,
+    )
+  }
+
   const argIn: string = argv._[0] || argv.input
   const argOut: string | undefined = argv._[1] || argv.output // the output can be omitted so this can be undefined
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -145,6 +145,17 @@ suite('CLI', () => {
     rimraf.sync('./test/resources/MultiSchema/foo')
   })
 
+  test('extra positional arguments (e.g. from an unquoted glob) error out instead of overwriting a file', () => {
+    const outFile = './test/resources/MultiSchema/out.d.ts'
+    expect(() =>
+      execSync(
+        `node dist/src/cli.js -i ./test/resources/MultiSchema/a.json ./test/resources/MultiSchema/b.yaml -o ${outFile}`,
+        {stdio: 'pipe'},
+      ),
+    ).toThrow()
+    expect(existsSync(outFile)).toBe(false)
+  })
+
   test('files in (-i), files out (-o) matching nested dir', () => {
     execSync(
       `node dist/src/cli.js -i "./test/resources/../../test/resources/MultiSchema2/" -o ./test/resources/MultiSchema2/out`,


### PR DESCRIPTION
Fixes #365.

`argIn`/`argOut` in `src/cli.ts` were read straight from `argv._[0]`/`argv._[1]`, so leftover positional args (e.g. from an unquoted glob expanding past `-i`'s single value) silently won over an explicitly-passed `--input`/`--output` flag, causing one file to be misread as an output path and overwritten. The CLI now errors out instead of guessing when it sees more positional args than it expects, or positional args alongside an explicit `-i`/`-o` flag.

Does not cover implicit fan-out for globbed `-i` with multiple positional args (that's a separate feature question, not addressed here).

Regression test: `test/cli.test.ts`.

auto-fix-bot:issue-365

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrKCYSvUKCae9aTzp6zCYT)_