### PR TITLE
Give a clear error for $ref cycles with no concrete base case

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,6 +1,5 @@
 import {JSONSchema4Type, JSONSchema4TypeName} from 'json-schema'
 import {findKey, includes, isPlainObject, map, omit} from 'lodash'
-import {format} from 'util'
 import {Options} from './'
 import {applySchemaTyping} from './applySchemaTyping'
 import type {AST, TInterface, TInterfaceParam, TIntersection, TNamedInterface, TTuple} from './types/AST'
@@ -237,7 +236,18 @@ function parseNonLiteral(
         type: 'UNION',
       }
     case 'REFERENCE':
-      throw Error(format('Refs should have been resolved by the resolver!', schema))
+      // If a $ref makes it this far unresolved, the most likely cause is a $ref
+      // cycle with no concrete base case -- eg. `definitions.bar` being nothing
+      // but `{"$ref": "#/definitions/bar"}`, which (directly, or through a chain
+      // of other $refs) only ever points back to itself and never bottoms out
+      // in an actual type. There's no TypeScript equivalent for that (it's like
+      // `type Bar = Bar`), so surface a targeted error instead of the generic
+      // one below.
+      throw new ReferenceError(
+        `Failed to resolve $ref "${schema.$ref}"` +
+          (keyNameFromDefinition ? ` in definition "${keyNameFromDefinition}"` : '') +
+          '. This usually means the $ref is part of a cycle with no concrete base case, so it can never resolve to an actual type.',
+      )
     case 'STRING':
       return {
         comment: schema.description,

--- a/test/e2e/refWithCycle.3.ts
+++ b/test/e2e/refWithCycle.3.ts
@@ -1,5 +1,7 @@
-export let exclude = true
-
+// A tight cycle: `definitions.bar` is nothing but a $ref back to itself, so it
+// never bottoms out in a concrete type (like `type Bar = Bar` in TypeScript).
+// This should produce a clear error rather than crash.
+// @see https://github.com/bcherny/json-schema-to-typescript/issues/76
 export const input = {
   additionalProperties: true,
   properties: {
@@ -15,3 +17,5 @@ export const input = {
   required: ['foo'],
   title: 'Cycle (3)',
 }
+
+export const error = true


### PR DESCRIPTION
Fixes #76.

A `$ref` that is only ever a $ref back to itself (directly, or through a chain of other $refs) never bottoms out in a concrete schema, so `json-schema-ref-parser`'s `dereference()` leaves the raw `$ref` in place; the parser's `case 'REFERENCE'` then hit its "should never happen" internal assertion. This replaces that assertion with an explicit error naming the offending `$ref`/definition, since such a schema is inherently unsatisfiable (like `type Bar = Bar`).

Does not cover normal recursive schemas (a definition referencing itself through an actual base type) — those already dereference correctly and are unaffected; verified with an additional manual repro during investigation.

Regression test: `test/e2e/refWithCycle.3.ts` (pre-existing fixture, previously excluded from the suite; now enabled with `error = true`).

auto-fix-bot:issue-76

_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01WrKCYSvUKCae9aTzp6zCYT)_