### PR TITLE
Emit JSON Schema defaults as JSDoc @default comments

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,8 +18,10 @@ main(
       'additionalProperties',
       'declareExternallyReferenced',
       'enableConstEnums',
+      'enableDefaultComments',
       'format',
       'ignoreMinAndMaxItems',
+      'prettifyDefaultComments',
       'strictIndexSignatures',
       'unknownAny',
       'unreachableDefinitions',
@@ -181,6 +183,8 @@ Boolean values can be set to false using the 'no-' prefix.
       Declare external schemas referenced via '$ref'?
   --enableConstEnums
       Prepend enums with 'const'?
+  --enableDefaultComments
+      Generate @default JSDoc comments for properties with a default value
   --inferStringEnumKeysFromValues
       Create enums from JSON enums instead of union types
   --format
@@ -190,6 +194,8 @@ Boolean values can be set to false using the 'no-' prefix.
       array types, before falling back to emitting unbounded arrays. Increase
       this to improve precision of emitted types, decrease it to improve
       performance, or set it to -1 to ignore minItems and maxItems.
+  --prettifyDefaultComments
+      Prettify object/array @default values. Disable to emit single-line JSON.
   --style.XXX=YYY
       Prettier configuration
   --unknownAny

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -34,7 +34,7 @@ async function expandDefaultComments(code: string): Promise<string> {
 }
 
 export async function format(code: string, options: Options): Promise<string> {
-  const expandedDefaults = await expandDefaultComments(code)
+  const expandedDefaults = options.prettifyDefaultComments ? await expandDefaultComments(code) : code
   if (!options.format) {
     return expandedDefaults
   }

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -1,9 +1,42 @@
 import {format as prettify} from 'prettier'
 import {Options} from './'
 
-export async function format(code: string, options: Options): Promise<string> {
-  if (!options.format) {
-    return code
+async function expandDefaultComments(code: string): Promise<string> {
+  const pattern = /^(\s*\* )@default \[\[__PRETTIFY_DEFAULT_JSON__:(.+)\]\]$/gm
+  let result = ''
+  let lastIndex = 0
+
+  for (const match of code.matchAll(pattern)) {
+    const [fullMatch, prefix, encodedDefault] = match
+    const index = match.index ?? 0
+    result += code.slice(lastIndex, index)
+
+    const formattedDefault = (
+      await prettify(decodeURIComponent(encodedDefault), {
+        parser: 'json5', // JSON5 lets Prettier print object keys without forcing strict JSON quoting.
+        printWidth: 20,
+        trailingComma: 'none',
+        singleQuote: false,
+      })
+    ).trimEnd()
+
+    const lines = formattedDefault.split('\n')
+    result += `${prefix}@default ${lines[0]}`
+    for (const line of lines.slice(1)) {
+      result += `\n${prefix}${line}`
+    }
+
+    lastIndex = index + fullMatch.length
   }
-  return prettify(code, {parser: 'typescript', ...options.style})
+
+  result += code.slice(lastIndex)
+  return result
+}
+
+export async function format(code: string, options: Options): Promise<string> {
+  const expandedDefaults = await expandDefaultComments(code)
+  if (!options.format) {
+    return expandedDefaults
+  }
+  return prettify(expandedDefaults, {parser: 'typescript', ...options.style})
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -494,6 +494,16 @@ function generateInterface(ast: TInterface, options: Options): string {
   )
 }
 
+function generateDefaultComment(defaultValue: unknown): string {
+  if (defaultValue !== null && typeof defaultValue === 'object') {
+    // The default value is not a primitive, so we need to format it.
+    // But we can't do that here because Prettier is asynchronous,
+    // so we encode the value and expand it later in the formatter.
+    return ` * @default [[__PRETTIFY_DEFAULT_JSON__:${encodeURIComponent(JSON.stringify(defaultValue))}]]`
+  }
+  return ` * @default ${JSON.stringify(defaultValue)}`
+}
+
 function generateComment(comment?: string, deprecated?: boolean, defaultValue?: unknown): string {
   const commentLines = ['/**']
   if (deprecated) {
@@ -503,7 +513,7 @@ function generateComment(comment?: string, deprecated?: boolean, defaultValue?: 
     commentLines.push(...comment.split('\n').map(_ => ' * ' + _))
   }
   if (defaultValue !== undefined) {
-    commentLines.push(` * @default ${JSON.stringify(defaultValue)}`)
+    commentLines.push(generateDefaultComment(defaultValue))
   }
   commentLines.push(' */')
   return commentLines.join('\n')

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -479,7 +479,9 @@ function generateInterface(ast: TInterface, options: Options): string {
             ? indexSignatureType
             : generateType(ast, options) + (isIndexSignature && options.strictIndexSignatures ? ' | undefined' : '')
         return (
-          (hasComment(ast) && !ast.standaloneName ? generateComment(ast.comment, ast.deprecated) + '\n' : '') +
+          (hasComment(ast) && !ast.standaloneName
+            ? generateComment(ast.comment, ast.deprecated, ast.default) + '\n'
+            : '') +
           (isIndexSignature ? keyName : escapeKeyName(keyName)) +
           (isRequired ? '' : '?') +
           ': ' +
@@ -492,13 +494,16 @@ function generateInterface(ast: TInterface, options: Options): string {
   )
 }
 
-function generateComment(comment?: string, deprecated?: boolean): string {
+function generateComment(comment?: string, deprecated?: boolean, defaultValue?: unknown): string {
   const commentLines = ['/**']
   if (deprecated) {
     commentLines.push(' * @deprecated')
   }
   if (typeof comment !== 'undefined') {
     commentLines.push(...comment.split('\n').map(_ => ' * ' + _))
+  }
+  if (defaultValue !== undefined) {
+    commentLines.push(` * @default ${JSON.stringify(defaultValue)}`)
   }
   commentLines.push(' */')
   return commentLines.join('\n')
@@ -512,7 +517,7 @@ function generateStandaloneEnum(ast: TEnum, options: Options): string {
   const isValidIdentifier = (key: string): boolean => /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key)
 
   return (
-    (hasComment(ast) ? generateComment(ast.comment, ast.deprecated) + '\n' : '') +
+    (hasComment(ast) ? generateComment(ast.comment, ast.deprecated, ast.default) + '\n' : '') +
     'export ' +
     (options.enableConstEnums ? 'const ' : '') +
     `enum ${toSafeString(ast.standaloneName)} {` +
@@ -532,7 +537,7 @@ function generateStandaloneEnum(ast: TEnum, options: Options): string {
 
 function generateStandaloneInterface(ast: TNamedInterface, options: Options): string {
   return (
-    (hasComment(ast) ? generateComment(ast.comment, ast.deprecated) + '\n' : '') +
+    (hasComment(ast) ? generateComment(ast.comment, ast.deprecated, ast.default) + '\n' : '') +
     `export interface ${toSafeString(ast.standaloneName)} ` +
     (ast.superTypes.length > 0
       ? `extends ${ast.superTypes.map(superType => toSafeString(superType.standaloneName)).join(', ')} `
@@ -543,7 +548,7 @@ function generateStandaloneInterface(ast: TNamedInterface, options: Options): st
 
 function generateStandaloneType(ast: ASTWithStandaloneName, options: Options): string {
   return (
-    (hasComment(ast) ? generateComment(ast.comment) + '\n' : '') +
+    (hasComment(ast) ? generateComment(ast.comment, ast.deprecated, ast.default) + '\n' : '') +
     `export type ${toSafeString(ast.standaloneName)} = ${generateType(
       omit<AST>(ast, 'standaloneName') as AST /* TODO */,
       options,

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -479,8 +479,8 @@ function generateInterface(ast: TInterface, options: Options): string {
             ? indexSignatureType
             : generateType(ast, options) + (isIndexSignature && options.strictIndexSignatures ? ' | undefined' : '')
         return (
-          (hasComment(ast) && !ast.standaloneName
-            ? generateComment(ast.comment, ast.deprecated, ast.default) + '\n'
+          (hasComment(ast, options) && !ast.standaloneName
+            ? generateComment(ast.comment, ast.deprecated, ast.default, options) + '\n'
             : '') +
           (isIndexSignature ? keyName : escapeKeyName(keyName)) +
           (isRequired ? '' : '?') +
@@ -494,17 +494,22 @@ function generateInterface(ast: TInterface, options: Options): string {
   )
 }
 
-function generateDefaultComment(defaultValue: unknown): string {
-  if (defaultValue !== null && typeof defaultValue === 'object') {
-    // The default value is not a primitive, so we need to format it.
-    // But we can't do that here because Prettier is asynchronous,
-    // so we encode the value and expand it later in the formatter.
-    return ` * @default [[__PRETTIFY_DEFAULT_JSON__:${encodeURIComponent(JSON.stringify(defaultValue))}]]`
+function generateDefaultComment(defaultValue: unknown, options: Options): string {
+  if (!options.enableDefaultComments) {
+    return ''
   }
-  return ` * @default ${JSON.stringify(defaultValue)}`
+  if (!options.prettifyDefaultComments || defaultValue === null || typeof defaultValue !== 'object') {
+    return ` * @default ${JSON.stringify(defaultValue)}`
+  }
+  return ` * @default [[__PRETTIFY_DEFAULT_JSON__:${encodeURIComponent(JSON.stringify(defaultValue))}]]`
 }
 
-function generateComment(comment?: string, deprecated?: boolean, defaultValue?: unknown): string {
+function generateComment(
+  comment: string | undefined,
+  deprecated: boolean | undefined,
+  defaultValue: unknown | undefined,
+  options: Options,
+): string {
   const commentLines = ['/**']
   if (deprecated) {
     commentLines.push(' * @deprecated')
@@ -513,7 +518,10 @@ function generateComment(comment?: string, deprecated?: boolean, defaultValue?: 
     commentLines.push(...comment.split('\n').map(_ => ' * ' + _))
   }
   if (defaultValue !== undefined) {
-    commentLines.push(generateDefaultComment(defaultValue))
+    const defaultComment = generateDefaultComment(defaultValue, options)
+    if (defaultComment) {
+      commentLines.push(defaultComment)
+    }
   }
   commentLines.push(' */')
   return commentLines.join('\n')
@@ -527,7 +535,7 @@ function generateStandaloneEnum(ast: TEnum, options: Options): string {
   const isValidIdentifier = (key: string): boolean => /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key)
 
   return (
-    (hasComment(ast) ? generateComment(ast.comment, ast.deprecated, ast.default) + '\n' : '') +
+    (hasComment(ast, options) ? generateComment(ast.comment, ast.deprecated, ast.default, options) + '\n' : '') +
     'export ' +
     (options.enableConstEnums ? 'const ' : '') +
     `enum ${toSafeString(ast.standaloneName)} {` +
@@ -547,7 +555,7 @@ function generateStandaloneEnum(ast: TEnum, options: Options): string {
 
 function generateStandaloneInterface(ast: TNamedInterface, options: Options): string {
   return (
-    (hasComment(ast) ? generateComment(ast.comment, ast.deprecated, ast.default) + '\n' : '') +
+    (hasComment(ast, options) ? generateComment(ast.comment, ast.deprecated, ast.default, options) + '\n' : '') +
     `export interface ${toSafeString(ast.standaloneName)} ` +
     (ast.superTypes.length > 0
       ? `extends ${ast.superTypes.map(superType => toSafeString(superType.standaloneName)).join(', ')} `
@@ -558,7 +566,7 @@ function generateStandaloneInterface(ast: TNamedInterface, options: Options): st
 
 function generateStandaloneType(ast: ASTWithStandaloneName, options: Options): string {
   return (
-    (hasComment(ast) ? generateComment(ast.comment, ast.deprecated, ast.default) + '\n' : '') +
+    (hasComment(ast, options) ? generateComment(ast.comment, ast.deprecated, ast.default, options) + '\n' : '') +
     `export type ${toSafeString(ast.standaloneName)} = ${generateType(
       omit<AST>(ast, 'standaloneName') as AST /* TODO */,
       options,

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,10 @@ export interface Options {
    */
   enableConstEnums: boolean
   /**
+   * Generate `@default` JSDoc comments for properties with a `default` value in the JSON Schema.
+   */
+  enableDefaultComments: boolean
+  /**
    * Create enums from JSON enums with eponymous keys
    */
   inferStringEnumKeysFromValues: boolean
@@ -70,6 +74,11 @@ export interface Options {
    * `minItems` and `maxItems`.
    */
   maxItems: number
+  /**
+   * Prettify object and array `@default` values into multi-line JSDoc comments.
+   * When disabled, complex defaults are emitted as a single-line JSON string.
+   */
+  prettifyDefaultComments: boolean
   /**
    * Append all index signatures with `| undefined` so that they are strictly typed.
    *
@@ -102,10 +111,12 @@ export const DEFAULT_OPTIONS: Options = {
   cwd: process.cwd(),
   declareExternallyReferenced: true,
   enableConstEnums: true,
+  enableDefaultComments: true,
   inferStringEnumKeysFromValues: false,
   format: true,
   ignoreMinAndMaxItems: false,
   maxItems: 20,
+  prettifyDefaultComments: true,
   strictIndexSignatures: false,
   style: {
     bracketSpacing: false,

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -127,6 +127,7 @@ function parseNonLiteral(
     case 'ALL_OF':
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -137,6 +138,7 @@ function parseNonLiteral(
       return {
         ...(options.unknownAny ? T_UNKNOWN : T_ANY),
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -144,6 +146,7 @@ function parseNonLiteral(
     case 'ANY_OF':
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -153,6 +156,7 @@ function parseNonLiteral(
     case 'BOOLEAN':
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -161,6 +165,7 @@ function parseNonLiteral(
     case 'CUSTOM_TYPE':
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         params: schema.tsType!,
@@ -175,6 +180,7 @@ function parseNonLiteral(
       if (!enumName) {
         return {
           comment: schema.description,
+          default: schema.default,
           deprecated: schema.deprecated,
           keyName,
           params: (schema as EnumJSONSchema).enum!.map(_ => parseLiteral(_, undefined)),
@@ -183,6 +189,7 @@ function parseNonLiteral(
       }
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: enumName,
@@ -198,6 +205,7 @@ function parseNonLiteral(
     case 'NEVER':
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -206,6 +214,7 @@ function parseNonLiteral(
     case 'NULL':
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -214,6 +223,7 @@ function parseNonLiteral(
     case 'NUMBER':
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -222,6 +232,7 @@ function parseNonLiteral(
     case 'OBJECT':
       return {
         comment: schema.description,
+        default: schema.default,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
         type: 'OBJECT',
@@ -230,6 +241,7 @@ function parseNonLiteral(
     case 'ONE_OF':
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -241,6 +253,7 @@ function parseNonLiteral(
     case 'STRING':
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -253,6 +266,7 @@ function parseNonLiteral(
         const maxItems = schema.maxItems!
         const arrayType: TTuple = {
           comment: schema.description,
+          default: schema.default,
           deprecated: schema.deprecated,
           keyName,
           maxItems,
@@ -270,6 +284,7 @@ function parseNonLiteral(
       } else {
         return {
           comment: schema.description,
+          default: schema.default,
           deprecated: schema.deprecated,
           keyName,
           standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -280,6 +295,7 @@ function parseNonLiteral(
     case 'UNION':
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -294,6 +310,7 @@ function parseNonLiteral(
     case 'UNNAMED_ENUM':
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         standaloneName: standaloneName(schema, keyNameFromDefinition, usedNames, options),
@@ -310,6 +327,7 @@ function parseNonLiteral(
       if (minItems > 0 || maxItems >= 0) {
         return {
           comment: schema.description,
+          default: schema.default,
           deprecated: schema.deprecated,
           keyName,
           maxItems: schema.maxItems,
@@ -325,6 +343,7 @@ function parseNonLiteral(
 
       return {
         comment: schema.description,
+        default: schema.default,
         deprecated: schema.deprecated,
         keyName,
         params,
@@ -361,6 +380,7 @@ function newInterface(
   const name = standaloneName(schema, keyNameFromDefinition, usedNames, options)!
   return {
     comment: schema.description,
+    default: schema.default,
     deprecated: schema.deprecated,
     keyName,
     params: parseSchema(schema, options, processed, usedNames, name),

--- a/src/types/AST.ts
+++ b/src/types/AST.ts
@@ -25,6 +25,7 @@ export type AST =
 
 export interface AbstractAST {
   comment?: string
+  default?: unknown
   keyName?: string
   standaloneName?: string
   type: AST_TYPE
@@ -43,6 +44,7 @@ export type ASTWithStandaloneName = AST & {standaloneName: string}
 export function hasComment(ast: AST): ast is ASTWithComment {
   return (
     ('comment' in ast && ast.comment != null && ast.comment !== '') ||
+    ('default' in ast && ast.default !== undefined) ||
     // Compare to true because ast.deprecated might be undefined
     ('deprecated' in ast && ast.deprecated === true)
   )

--- a/src/types/AST.ts
+++ b/src/types/AST.ts
@@ -41,10 +41,10 @@ export type ASTWithComment = AST & {comment: string}
 export type ASTWithName = AST & {keyName: string}
 export type ASTWithStandaloneName = AST & {standaloneName: string}
 
-export function hasComment(ast: AST): ast is ASTWithComment {
+export function hasComment(ast: AST, options?: {enableDefaultComments?: boolean}): ast is ASTWithComment {
   return (
     ('comment' in ast && ast.comment != null && ast.comment !== '') ||
-    ('default' in ast && ast.default !== undefined) ||
+    (options?.enableDefaultComments !== false && 'default' in ast && ast.default !== undefined) ||
     // Compare to true because ast.deprecated might be undefined
     ('deprecated' in ast && ast.deprecated === true)
   )

--- a/test/default.test.ts
+++ b/test/default.test.ts
@@ -108,4 +108,58 @@ suite('default keyword', () => {
 
     expect(output).toContain(['* @default [', '*   { foo_bar: 1 },', '*   null,', '*   "testing"', '* ]'].join('\n'))
   })
+
+  test('does not generate @default comments when enableDefaultComments is false', async () => {
+    const output = await compile(
+      {
+        title: 'NoDefaults',
+        type: 'object',
+        properties: {
+          stringValue: {
+            type: 'string',
+            default: 'hello',
+          },
+          numberValue: {
+            type: 'number',
+            default: 3,
+          },
+        },
+      },
+      'NoDefaults',
+      {enableDefaultComments: false},
+    )
+
+    expect(output).not.toContain('@default')
+  })
+
+  test('does not prettify object/array @default values when prettifyDefaultComments is false', async () => {
+    const output = normalizeCommentIndentation(
+      await compile(
+        {
+          title: 'NonPrettifiedDefaults',
+          type: 'object',
+          default: {
+            enabled: true,
+            nested: {key: 'value'},
+          },
+          properties: {
+            config: {
+              type: 'object',
+              default: {a: 1, b: 2},
+            },
+            values: {
+              type: 'array',
+              default: [1, 2, 3],
+            },
+          },
+        },
+        'NonPrettifiedDefaults',
+        {prettifyDefaultComments: false},
+      ),
+    )
+
+    expect(output).toContain('* @default {"enabled":true,"nested":{"key":"value"}}')
+    expect(output).toContain('* @default {"a":1,"b":2}')
+    expect(output).toContain('* @default [1,2,3]')
+  })
 })

--- a/test/default.test.ts
+++ b/test/default.test.ts
@@ -1,0 +1,34 @@
+import {describe, expect, test} from 'bun:test'
+import {compile} from '../src'
+import {hasOnly} from './e2eCases'
+
+const suite = hasOnly() ? describe.skip : describe
+
+suite('default keyword', () => {
+  test('renders schema defaults as JSDoc @default comments', async () => {
+    const output = await compile(
+      {
+        title: 'ExampleSchema',
+        type: 'object',
+        default: {enabled: true},
+        description: 'Schema comment',
+        properties: {
+          enabled: {
+            type: 'boolean',
+            default: true,
+          },
+          retries: {
+            type: 'number',
+            default: 3,
+            description: 'Retry count',
+          },
+        },
+      },
+      'ExampleSchema',
+    )
+
+    expect(output).toContain('* @default {"enabled":true}')
+    expect(output).toContain('* @default true')
+    expect(output).toContain('* @default 3')
+  })
+})

--- a/test/default.test.ts
+++ b/test/default.test.ts
@@ -4,31 +4,108 @@ import {hasOnly} from './e2eCases'
 
 const suite = hasOnly() ? describe.skip : describe
 
+function normalizeCommentIndentation(output: string): string {
+  return output.replace(/^\s+\*/gm, '*')
+}
+
 suite('default keyword', () => {
-  test('renders schema defaults as JSDoc @default comments', async () => {
-    const output = await compile(
-      {
-        title: 'ExampleSchema',
-        type: 'object',
-        default: {enabled: true},
-        description: 'Schema comment',
-        properties: {
-          enabled: {
-            type: 'boolean',
-            default: true,
-          },
-          retries: {
-            type: 'number',
-            default: 3,
-            description: 'Retry count',
+  test('renders JSON primitive defaults as one-line JSDoc @default comments', async () => {
+    const output = normalizeCommentIndentation(
+      await compile(
+        {
+          title: 'PrimitiveDefaults',
+          type: 'object',
+          properties: {
+            stringValue: {
+              type: 'string',
+              default: 'hello',
+            },
+            numberValue: {
+              type: 'number',
+              default: 3,
+            },
+            booleanValue: {
+              type: 'boolean',
+              default: true,
+            },
+            nullValue: {
+              type: 'null',
+              default: null,
+            },
           },
         },
-      },
-      'ExampleSchema',
+        'PrimitiveDefaults',
+      ),
     )
 
-    expect(output).toContain('* @default {"enabled":true}')
-    expect(output).toContain('* @default true')
+    expect(output).toContain('* @default "hello"')
     expect(output).toContain('* @default 3')
+    expect(output).toContain('* @default true')
+    expect(output).toContain('* @default null')
+  })
+
+  test('renders object and array defaults as multiline JSDoc @default comments', async () => {
+    const output = normalizeCommentIndentation(
+      await compile(
+        {
+          title: 'ComplexDefaults',
+          type: 'object',
+          default: {
+            enabled: true,
+            nested: {
+              '1+1': 2,
+              foo: 'bar',
+            },
+            arr: [{'123': null}],
+          },
+          properties: {
+            config: {
+              type: 'object',
+              default: {
+                enabled: true,
+                nested: {
+                  hello_world: 0,
+                  'x-y-z': 'u-v-w',
+                },
+              },
+            },
+            values: {
+              type: 'array',
+              default: [{foo_bar: 1}, null, 'testing'],
+            },
+          },
+        },
+        'ComplexDefaults',
+      ),
+    )
+
+    expect(output).toContain(
+      [
+        '* @default {',
+        '*   enabled: true,',
+        '*   nested: {',
+        '*     "1+1": 2,',
+        '*     foo: "bar"',
+        '*   },',
+        '*   arr: [',
+        '*     { "123": null }',
+        '*   ]',
+        '* }',
+      ].join('\n'),
+    )
+
+    expect(output).toContain(
+      [
+        '* @default {',
+        '*   enabled: true,',
+        '*   nested: {',
+        '*     hello_world: 0,',
+        '*     "x-y-z": "u-v-w"',
+        '*   }',
+        '* }',
+      ].join('\n'),
+    )
+
+    expect(output).toContain(['* @default [', '*   { foo_bar: 1 },', '*   null,', '*   "testing"', '* ]'].join('\n'))
   })
 })

--- a/test/e2eCases.ts
+++ b/test/e2eCases.ts
@@ -49,5 +49,7 @@ export function getTestCases(): [string, TestCase][] {
 }
 
 export function getOptions(testCase: TestCase): Options {
-  return merge(testCase.options, {$refOptions: {resolve: {http: httpWithCacheResolver}}})
+  return merge({enableDefaultComments: false}, testCase.options, {
+    $refOptions: {resolve: {http: httpWithCacheResolver}},
+  })
 }


### PR DESCRIPTION
## Summary

This PR adds support for emitting JSON Schema `default` values as TypeScript JSDoc `@default` comments.

Primitive defaults are added inline, while object and array defaults are formatted across multiple lines for readability.

Two new options provide ways to opt-out of the functionality:

| Option | Default | Description |
|---|---|---|
| `enableDefaultComments` | `true` | Set to `false` to suppress all `@default` comments |
| `prettifyDefaultComments` | `true` | Set to `false` to emit object/array defaults as single-line JSON |


## What changed

- emit `@default` JSDoc comments from schema `default`
- keep primitive defaults on one line
- format object and array defaults as multiline comments using Prettier

## Example

JSON Schema input:

```json
{
  "type": "object",
  "properties": {
    "enabled": {
      "type": "boolean",
      "default": true
    },
    "config": {
      "type": "object",
      "default": {
        "foo": "bar",
        "nested": {
          "1+1": 2,
          "hello": "world"
        }
      }
    }
  }
}
```

TypeScript output:

```ts
export interface Example {
  /**
   * @default true
   */
  enabled?: boolean;
  /**
   * @default {
   *   foo: "bar",
   *   nested: {
   *     "1+1": 2,
   *     hello: "world"
   *   }
   * }
   */
  config?: {
    [k: string]: unknown;
  };
}
```

## Tests

Added focused coverage for:
- all JSON primitives
- arrays
- nested objects
- multiline formatting behavior for complex defaults
- new options

The E2E test suite runs with `enableDefaultComments: false` to avoid regenerating a massive snapshot (which would otherwise results in +256,765 -256,449 changes). If you prefer to update the E2E tests, you can just revert or skip the last commit in this PR.