### PR TITLE
Auto-approve and auto-merge pull requests opened by claude[bot]

### DIFF
--- a/.github/workflows/auto-merge-claude.yml
+++ b/.github/workflows/auto-merge-claude.yml
@@ -1,0 +1,53 @@
+name: Auto-merge Claude PRs
+
+# Pull requests opened by the claude[bot] GitHub App are approved and queued for
+# squash merge as soon as they are marked ready for review. Branch protection
+# still applies: the merge waits for the `ci-ok` check, so nothing lands red.
+#
+# Approval uses the built-in Actions token (github-actions[bot] counts as the
+# one required review). Enabling auto-merge uses AUTO_MERGE_TOKEN, a
+# fine-grained personal access token of the repository owner with Contents and
+# Pull requests write access. GitHub suppresses workflow runs for pushes it
+# attributes to the built-in token, so a merge queued with it would land on
+# master without running publish.yml. The token makes the merge count as the
+# owner's, and the release publishes.
+#
+# pull_request_target runs with write access on the base branch's workflow
+# file. This job never checks out or executes anything from the pull request.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  approve-and-queue:
+    # claude[bot] is app id 209825114; the login alone could be spoofed by a
+    # user account named the same way, the id cannot.
+    if: >-
+      github.event.pull_request.user.id == 209825114 &&
+      github.event.pull_request.user.type == 'Bot' &&
+      !github.event.pull_request.draft
+    runs-on: ubuntu-latest
+    steps:
+    - name: Approve
+      env:
+        GH_TOKEN: ${{ github.token }}
+        PR: ${{ github.event.pull_request.number }}
+      run: gh pr review "$PR" --repo "$GITHUB_REPOSITORY" --approve --body "Auto-approved: opened by claude[bot]."
+    - name: Enable auto-merge (squash)
+      env:
+        GH_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
+        PR: ${{ github.event.pull_request.number }}
+      run: |
+        if [ -z "$GH_TOKEN" ]; then
+          echo "::error::AUTO_MERGE_TOKEN is not set. Add a fine-grained PAT (Contents: write, Pull requests: write) as a repository secret; see the comment at the top of this workflow."
+          exit 1
+        fi
+        # A pull request that is already green and approved cannot have
+        # auto-merge enabled; merge it outright instead.
+        gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" --auto --squash ||
+          gh pr merge "$PR" --repo "$GITHUB_REPOSITORY" --squash

--- a/.github/workflows/auto-merge-claude.yml
+++ b/.github/workflows/auto-merge-claude.yml
@@ -12,6 +12,11 @@ name: Auto-merge Claude PRs
 # master without running publish.yml. The token makes the merge count as the
 # owner's, and the release publishes.
 #
+# The token lives in the `auto-merge` environment, which only jobs running on a
+# protected branch may enter. pull_request_target runs on master, so this job
+# qualifies; a workflow on a bot-pushed branch (which any push-triggered
+# workflow file on that branch would be) cannot read the secret.
+#
 # pull_request_target runs with write access on the base branch's workflow
 # file. This job never checks out or executes anything from the pull request.
 
@@ -32,6 +37,7 @@ jobs:
       github.event.pull_request.user.type == 'Bot' &&
       !github.event.pull_request.draft
     runs-on: ubuntu-latest
+    environment: auto-merge
     steps:
     - name: Approve
       env:


### PR DESCRIPTION
Adds `.github/workflows/auto-merge-claude.yml`. When claude[bot] opens a pull request (or marks a draft ready for review), the workflow approves it with the built-in Actions token and enables squash auto-merge. Branch protection still requires the `ci-ok` check, so nothing lands red. Drafts are skipped, and the author check is on the app's user id, not its login.

**One-time setup before merging this:** create a fine-grained personal access token scoped to this repository with **Contents: write** and **Pull requests: write**, then store it as a secret of the `auto-merge` environment (already created; only jobs on protected branches can enter it, so a workflow on a bot-pushed branch cannot read the token):

```sh
gh secret set AUTO_MERGE_TOKEN --env auto-merge --repo bcherny/json-schema-to-typescript
```

Why a token instead of the built-in one: GitHub does not run workflows for pushes it attributes to the built-in Actions token. A merge queued with it would land on master without running `publish.yml`, so version bumps would never publish. Enabling auto-merge with the owner's token makes the merge count as the owner's and publishing works.

Tradeoff, stated plainly: with this workflow no human reads a claude[bot] diff before it lands, and since #794 a version bump on master publishes to npm. CI checks that tests pass, not what the code intends. If that is too much for release PRs specifically, a follow-up can skip PRs that change `version` in package.json and leave those to a human Merge.

Verify after the first bot PR merges: the Publish workflow should show a run for that push to master.